### PR TITLE
Add piazza benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,7 @@ path = "benchmarks/multitail/multitail.rs"
 [[bin]]
 name = "tpc_w"
 path = "benchmarks/tpc_w/tpc_w.rs"
+
+[[bin]]
+name = "piazza"
+path = "benchmarks/piazza/piazza.rs"

--- a/benchmarks/piazza/piazza.rs
+++ b/benchmarks/piazza/piazza.rs
@@ -228,8 +228,7 @@ fn main() {
         "all" => populate_taking(nclasses, nusers, taking_putter, Fanout::All),
         "few" => populate_taking(nclasses, nusers, taking_putter, Fanout::Few),
         _ => {
-            println!("Invalid fanout configuration");
-            return
+            unreachable!();
         }
     }
 
@@ -238,8 +237,7 @@ fn main() {
         "single"  => domain_config = DomainConfig::Single,
         "peruser" => domain_config = DomainConfig::PerUser,
         _ => {
-            println!("Invalid domain configuration");
-            return
+            unreachable!();
         }
     }
 
@@ -285,8 +283,7 @@ fn main() {
                 app.log_user(uid.into(), &domain_config);
             },
             _ => {
-                println!("wrong benchmark!");
-                return
+                unreachable!();
             }
         };
 

--- a/benchmarks/piazza/piazza.rs
+++ b/benchmarks/piazza/piazza.rs
@@ -243,23 +243,14 @@ fn main() {
         }
     }
 
-    match benchmark.as_ref() {
-        "migration" => {
-            for pid in 0..nposts {
-                post_putter.put(vec![
-                    pid.into(),
-                    (pid % nclasses).into(),
-                    (pid % nusers).into(),
-                    "post".into()
-                    ]);
-            }
-        },
-        "write" => {
-
-        }
-        _ => {
-            println!("wrong benchmark!");
-            return
+    if benchmark == "migration" {
+        for pid in 0..nposts {
+            post_putter.put(vec![
+                pid.into(),
+                (pid % nclasses).into(),
+                (pid % nusers).into(),
+                "post".into()
+                ]);
         }
     }
 
@@ -273,19 +264,17 @@ fn main() {
     }
 
     println!("Starting benchmark...");
-    for uid in 0..(nusers) {
+    for uid in 0..nusers {
         let start;
         let end;
-
+        start = time::Instant::now();
         match benchmark.as_ref() {
             "migration" => {
-                start = time::Instant::now();
                 app.log_user(uid.into(), &domain_config);
 
                 end = time::Instant::now().duration_since(start);
             },
             "write" => {
-                start = time::Instant::now();
                 for i in 0..1000 {
                     post_putter.put(vec![i.into(), (i % nclasses).into(), (i % nusers).into(), "post".into()]);
                 }

--- a/benchmarks/piazza/piazza.rs
+++ b/benchmarks/piazza/piazza.rs
@@ -179,17 +179,14 @@ fn main() {
             for pid in 0..nposts {
                 post_putter.put(vec![
                     pid.into(),
-                    (pid / nclasses).into(),
-                    (pid / nusers).into(),
+                    (pid % nclasses).into(),
+                    (pid % nusers).into(),
                     "post".into()
                     ]);
             }
         },
         "write" => {
-            // login nusers
-            for i in 0..nusers {
-                app.log_user(i.into());
-            }
+
         }
         _ => {
             println!("wrong benchmark!");
@@ -219,12 +216,14 @@ fn main() {
             },
             "write" => {
                 start = time::Instant::now();
-                for cid in 0..nclasses {
-                    post_putter.put(vec![0.into(), cid.into(), uid.into(), "post".into()]);
+                for i in 0..1000 {
+                    post_putter.put(vec![i.into(), (i % nclasses).into(), (i % nusers).into(), "post".into()]);
                 }
                 end = time::Instant::now().duration_since(start);
 
                 thread::sleep(time::Duration::from_millis(1000));
+
+                app.log_user(uid.into());
             },
             _ => {
                 println!("wrong benchmark!");

--- a/benchmarks/piazza/piazza.rs
+++ b/benchmarks/piazza/piazza.rs
@@ -263,8 +263,8 @@ fn main() {
         }
     }
 
-    println!("Finished seeding! Sleeping for 1 second...");
-    thread::sleep(time::Duration::from_millis(1000));
+    println!("Finished seeding! Sleeping...");
+    thread::sleep(time::Duration::from_millis(100));
 
 
     let mut times = Vec::new();
@@ -291,7 +291,7 @@ fn main() {
                 }
                 end = time::Instant::now().duration_since(start);
 
-                thread::sleep(time::Duration::from_millis(1000));
+                thread::sleep(time::Duration::from_millis(100));
 
                 app.log_user(uid.into(), &domain_config);
             },

--- a/benchmarks/piazza/piazza.rs
+++ b/benchmarks/piazza/piazza.rs
@@ -313,28 +313,18 @@ fn main() {
 }
 
 fn max_duration(stats: &Vec<f64>) -> f64 {
-    let max = stats.iter().fold(0f64, |acc, el| {
+    stats.iter().fold(0f64, |acc, el| {
         f64::max(acc, *el)
-    });
-
-    max
+    })
 }
 
 fn min_duration(stats: &Vec<f64>) -> f64 {
-    let min_start = stats[0];
-    let min = stats.iter().fold(min_start, |acc, el| {
+    stats.iter().fold(stats[0], |acc, el| {
         f64::min(acc, *el)
-    });
-
-    min
+    })
 }
 
 
 fn avg(stats: &Vec<f64>) -> f64 {
-    let sum = stats.iter().fold(0f64, |acc, el| {
-        acc + (el / stats.len() as f64)
-
-    });
-
-    sum
+    stats.iter().sum::<f64>() / stats.len() as f64
 }

--- a/benchmarks/piazza/piazza.rs
+++ b/benchmarks/piazza/piazza.rs
@@ -1,0 +1,176 @@
+extern crate distributary;
+
+#[macro_use]
+extern crate clap;
+
+use std::{thread, time};
+
+use distributary::{DataType, JoinBuilder, Blender, Base, NodeAddress, Filter, Mutator};
+
+pub struct Piazza {
+    pub soup: Blender,
+    user: NodeAddress,
+    post: NodeAddress,
+    class: NodeAddress,
+    taking: NodeAddress,
+}
+
+impl Piazza {
+    // Create the base nodes for our Piazza application
+    pub fn new() -> Self {
+        let mut g = Blender::new();
+
+        let (user, post, class, taking);
+
+
+        {
+            let mut mig = g.start_migration();
+
+            // add a user account base table
+            user = mig.add_ingredient("user", &["uid", "username", "hash"], Base::default());
+
+            // add a post base table
+            post = mig.add_ingredient("post", &["pid", "cid", "author", "content"], Base::default());
+
+            // add a class base table
+            class = mig.add_ingredient("class", &["cid", "classname"], Base::default());
+
+            // associations between users and classes
+            taking = mig.add_ingredient("taking", &["uid", "cid"], Base::default());
+
+            // commit migration
+            mig.commit();
+        }
+
+        Piazza {
+            soup: g,
+            user: user,
+            post: post,
+            class: class,
+            taking: taking,
+        }
+    }
+
+    pub fn log_user(&mut self, uid: DataType) {
+
+        let visible_posts;
+
+        let mut mig = self.soup.start_migration();
+
+        // classes user is taking
+        let class_filter = Filter::new(self.taking, &[Some(uid.into()), None]);
+
+        let user_classes = mig.add_ingredient("class_filter", &["uid", "cid"], class_filter);
+        // add visible posts to user
+        // only posts from classes the user is taking should be visible
+        let j = JoinBuilder::new(vec![(self.post, 0), (self.post, 1), (self.post, 2), (self.post, 3)])
+                .from(self.post, vec![0, 1, 0, 0])
+                .join(user_classes, vec![0, 1]);
+
+        visible_posts = mig.add_ingredient("visible_posts", &["pid", "cid", "author", "content"], j);
+
+        // maintain visible_posts
+        mig.maintain(visible_posts, 0);
+
+        // commit migration
+        mig.commit();
+
+    }
+}
+
+fn populate_users(nusers: i64, users_putter: Mutator) {
+    for i in 0..nusers {
+        users_putter.put(vec![i.into(), "user".into(), "pass".into()]);
+    }
+}
+
+fn populate_classes(nclasses: i64, class_putter: Mutator) {
+    for i in 0..nclasses {
+        class_putter.put(vec![i.into(), i.into()]);
+    }
+}
+
+fn populate_taking(nclasses: i64, nusers: i64, taking_putter: Mutator) {
+    for i in 0..nclasses {
+        for j in 0..nusers {
+            taking_putter.put(vec![j.into(), i.into()]);
+        }
+    }
+}
+
+// writes a post for each class
+fn write_posts(nclasses: i64, uid: i64, post_putter: &Mutator) {
+    for cid in 0..nclasses {
+        post_putter.put(vec![0.into(), cid.into(), uid.into(), "post".into()]);
+    }
+}
+
+fn main() {
+    use clap::{Arg, App};
+    let args = App::new("piazza")
+        .version("0.1")
+        .about("Benchmarks Piazza-like application with some security policies.")
+        .arg(Arg::with_name("runtime")
+            .short("r")
+            .long("runtime")
+            .value_name("N")
+            .default_value("60")
+            .help("Benchmark runtime in seconds"))
+        .arg(Arg::with_name("nclasses")
+            .short("c")
+            .long("classes")
+            .value_name("N")
+            .default_value("1000")
+            .help("Number of classes to prepopulate the database with"))
+        .arg(Arg::with_name("nusers")
+            .short("u")
+            .long("users")
+            .value_name("N")
+            .default_value("100")
+            .help("Number of users to prepopulate the database with"))
+        .arg(Arg::with_name("csv")
+            .required(false)
+            .help("Print output in CSV format."))
+        .get_matches();
+
+
+    println!("Creating app...");
+    let mut app = Piazza::new();
+    println!("Done with app creation.");
+
+    let nusers = value_t_or_exit!(args, "nusers", i64);
+    let nclasses = value_t_or_exit!(args, "nclasses", i64);
+
+    let class_putter = app.soup.get_mutator(app.class);
+    let user_putter = app.soup.get_mutator(app.user);
+    let taking_putter = app.soup.get_mutator(app.taking);
+    let post_putter = app.soup.get_mutator(app.post);
+
+    println!("Populating db...", );
+    populate_users(nusers, user_putter);
+    populate_classes(nclasses, class_putter);
+    populate_taking(nclasses, nusers, taking_putter);
+    println!("Finished seeding! Sleeping for 1 second...");
+    thread::sleep(time::Duration::from_millis(1000));
+
+    println!("Starting benchmark!");
+    println!("Logging in users...");
+    let start = time::Instant::now();
+    let mut elapsed_secs: f64;
+    for i in 0..nusers {
+        app.log_user(i.into());
+        write_posts(nclasses, i, &post_putter);
+        let elapsed = time::Instant::now().duration_since(start);
+        elapsed_secs = (elapsed.as_secs() as f64) +
+                       (elapsed.subsec_nanos() as f64 / 1_000_000_000.0);
+        if elapsed_secs > 30.0 {
+            break;
+        }
+
+        let avg : f64 = ((nusers as f64)*(nclasses as f64)*(i as f64) as f64) / elapsed_secs;
+        // println!("PUTS {:?} posts in elapsed_secs {:?}", nusers*nclasses, elapsed_secs);
+        println!("avg {:?}",  avg);
+    }
+
+    println!("Done with benchmark.");
+}

--- a/src/flow/domain/local.rs
+++ b/src/flow/domain/local.rs
@@ -246,7 +246,7 @@ impl<T: Hash + Eq + Clone> State<T> {
         rclones.extend((0..(self.state.len() - 1)).into_iter().map(|_| r.clone()));
         rclones.push(r);
 
-        self.rows.saturating_add(1);
+        self.rows = self.rows.saturating_add(1);
         for s in &mut self.state {
             let r = rclones.swap_remove(0);
             match s.1 {
@@ -290,7 +290,7 @@ impl<T: Hash + Eq + Clone> State<T> {
         // this will currently remove *all* matching rows, whereas we probably only want to remove
         // the *first* row. when that change is made, this next line will be correct (except if
         // there's no match I guess).
-        self.rows.saturating_sub(1);
+        self.rows = self.rows.saturating_sub(1);
         for s in &mut self.state {
             match s.1 {
                 KeyedState::Single(ref mut map) => {
@@ -366,6 +366,7 @@ impl<T: Hash + Eq + Clone> State<T> {
     }
 
     pub fn clear(&mut self) {
+        self.rows = 0;
         for s in &mut self.state {
             match s.1 {
                 KeyedState::Single(ref mut map) => map.clear(),

--- a/src/flow/domain/local.rs
+++ b/src/flow/domain/local.rs
@@ -344,7 +344,7 @@ impl<T: Hash + Eq + Clone> State<T> {
     }
 
     pub fn len(&self) -> usize {
-        if self.state.is_empty() { 0 } else { self.rows }
+        self.rows
     }
 
     pub fn nkeys(&self) -> usize {

--- a/src/flow/domain/mod.rs
+++ b/src/flow/domain/mod.rs
@@ -29,6 +29,7 @@ macro_rules! dur_to_ns {
     }}
 }
 
+#[allow(missing_docs)]
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy, Debug)]
 pub struct Index(usize);
 
@@ -44,6 +45,7 @@ impl Into<usize> for Index {
     }
 }
 
+#[allow(missing_docs)]
 impl Index {
     pub fn index(&self) -> usize {
         self.0

--- a/src/flow/migrate/materialization.rs
+++ b/src/flow/migrate/materialization.rs
@@ -710,7 +710,7 @@ fn trace<T>(graph: &Graph,
                             ack: tx,
                         })
                         .unwrap();
-                    let mut size = rx.recv().unwrap_or(0);
+                    let mut size = rx.recv().expect("stateful parent should have state");
 
                     // compute the total cost
                     // replay cost

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,7 @@ pub use flow::{Blender, Migration, NodeAddress, Mutator};
 pub use flow::node::StreamUpdate;
 pub use flow::sql_to_flow::{SqlIncorporator, ToFlowParts};
 pub use flow::data::DataType;
+pub use flow::domain::Index;
 pub use ops::Datas;
 pub use ops::base::Base;
 pub use ops::grouped::aggregate::{Aggregator, Aggregation};


### PR DESCRIPTION
Benchmark for Piazza application.

This measures two types of benchmak ```migration``` and ```write```.

```migration``` fills the db with users, classes, posts and relations between users and classes (```taking``` base node). Then, it times how long it takes to login a user. Each user login corresponds to one migration that creates a "parallel universe" for that user.

```write``` prepopulates the db similarly. Then, it logs some users and it measures the time it takes to perform a batch of writes. 

There are two important configurations in this benchmark ```dcfg``` and ```fanout```.  ```dcfg``` specifies the domain configuration of the graph, either a single domain or a domain per user. ```fanout``` specifies the fanout of a write passing through the ```taking``` base node (how many classes each user is taking).