### PR TITLE
Move filter merge after reuse

### DIFF
--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -291,9 +291,32 @@ impl MirNode {
         self.ancestors.push(a)
     }
 
+    pub fn remove_ancestor(&mut self, a: MirNodeRef) {
+        match self.ancestors
+                .iter()
+                .position(|x| x.borrow().versioned_name() == a.borrow().versioned_name()) {
+                    None => (),
+                    Some(idx) => {
+                            self.ancestors.remove(idx);
+                    }
+                }
+    }
+
     pub fn add_child(&mut self, c: MirNodeRef) {
         self.children.push(c)
     }
+
+    pub fn remove_child(&mut self, a: MirNodeRef) {
+        match self.children
+                .iter()
+                .position(|x| x.borrow().versioned_name() == a.borrow().versioned_name()) {
+                    None => (),
+                    Some(idx) => {
+                            self.children.remove(idx);
+                    }
+                }
+    }
+
 
     pub fn add_column(&mut self, c: Column) {
         self.columns.push(c.clone());

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -152,6 +152,11 @@ impl MirQuery {
         rewrite::pull_required_base_columns(&mut self);
         optimize::optimize(self)
     }
+
+    pub fn optimize_post_reuse(mut self) -> MirQuery {
+        optimize::optimize_post_reuse(&mut self);
+        self
+    }
 }
 
 impl Display for MirQuery {

--- a/src/mir/optimize.rs
+++ b/src/mir/optimize.rs
@@ -1,5 +1,7 @@
-use mir::{MirQuery, MirNodeRef, MirNodeType};
+use mir::{MirQuery, MirNodeRef, MirNodeType, MirNode};
 use std::collections::HashMap;
+use nom_sql::Operator;
+use flow::core::DataType;
 
 pub fn optimize(q: MirQuery) -> MirQuery {
     //remove_extraneous_projections(&mut q);
@@ -7,21 +9,11 @@ pub fn optimize(q: MirQuery) -> MirQuery {
 }
 
 pub fn optimize_post_reuse(q: &mut MirQuery) {
-  let chains = find_filter_chains(q);
-  println!("filter chains are {:?}", chains );
-  for chain in chains {
-    merge_filter_chain(q, chain);
-  }
+  find_and_merge_filter_chains(q);
 }
 
-fn merge_filter_chain(q: &mut MirQuery, chain: Vec<MirNodeRef>) {
-
-}
-
-fn find_filter_chains(q: &MirQuery) -> Vec<Vec<MirNodeRef>> {
-  let mut chains = Vec::new();
-
-  let mut current_chain = Vec::new();
+fn find_and_merge_filter_chains(q: &MirQuery) {
+  let mut chained_filters = Vec::new();
   // depth first search
   let mut node_stack = Vec::new();
   node_stack.extend(q.roots.iter().cloned());
@@ -31,6 +23,7 @@ fn find_filter_chains(q: &MirQuery) -> Vec<Vec<MirNodeRef>> {
   while !node_stack.is_empty() {
     let n = node_stack.pop().unwrap();
     let node_name = n.borrow().versioned_name();
+    let mut end_chain = false;
     if visited_nodes.contains_key(&node_name) {
       continue
     }
@@ -38,42 +31,106 @@ fn find_filter_chains(q: &MirQuery) -> Vec<Vec<MirNodeRef>> {
     visited_nodes.insert(node_name, true);
 
     match n.borrow().inner {
-      MirNodeType::Filter { .. } => try_add_node_to_chain(&n, &mut current_chain, &mut chains),
-      _ => end_filter_chain(&mut current_chain, &mut chains),
+      MirNodeType::Filter { .. } => {
+        try_add_node_to_chain(&n, &mut chained_filters);
+      }
+      _ => {
+        // we need this because n most likely will be a children of
+        // last_node. if that's the case, mutably borrowing the
+        // child in end_filter_chain will cause a BorrowMutError
+        // because it was already borrowed in the match.
+        end_chain = true;
+      }
+    }
+
+    if end_chain {
+      end_filter_chain(&mut chained_filters);
     }
 
     for child in n.borrow().children.iter() {
       node_stack.push(child.clone());
     }
   }
-
-  chains
 }
 
 fn try_add_node_to_chain(node: &MirNodeRef,
-                        current_chain: &mut Vec<MirNodeRef>,
-                        chains: &mut Vec<Vec<MirNodeRef>>) {
+                        chained_filters: &mut Vec<MirNodeRef>) {
   // any filter node can start a new chain
-  if current_chain.is_empty() {
-    current_chain.push(node.clone());
-  } else if node.borrow().ancestors.len() == 1 { // only nodes with a single ancestor can be added to the chain
-    current_chain.push(node.clone());
+  if chained_filters.is_empty() {
+    chained_filters.push(node.clone());
+  } else if node.borrow().ancestors.len() == 1 {
+    chained_filters.push(node.clone());
   } else {
-    end_filter_chain(current_chain, chains);
+    end_filter_chain(chained_filters);
+    return
   }
 
-  if node.borrow().children.len() > 1 {
-    end_filter_chain(current_chain, chains);
+  if node.borrow().children.len() != 1 {
+    end_filter_chain(chained_filters);
   }
-
-
 }
 
-fn end_filter_chain(current_chain: &mut Vec<MirNodeRef>, chains: &mut Vec<Vec<MirNodeRef>>) {
-  if !current_chain.is_empty() {
-    chains.push(current_chain.to_vec());
-    current_chain.clear();
+fn end_filter_chain(chained_filters: &mut Vec<MirNodeRef>) {
+  if chained_filters.len() < 2 {
+    chained_filters.clear();
+    return;
   }
+
+  {
+    let first_node = chained_filters.first().unwrap();
+    let last_node = chained_filters.last().unwrap();
+    let schema_version = first_node.borrow().from_version.clone();
+
+    let name = chained_filters.iter().fold("merged_filter_".to_string(),
+                                          |mut acc, ref node| {
+                                            acc.push_str(node.borrow().name());
+                                            acc
+                                          });
+
+    let prev_node = first_node.borrow().ancestors.first().unwrap().clone();
+    let fields: Vec<_> = prev_node.borrow().columns().iter().cloned().collect();
+    let merged_conditions = to_conditions(chained_filters, fields.len());
+
+    let merged_filter = MirNode::new(name.as_str(),
+                                     schema_version,
+                                     fields,
+                                     MirNodeType::Filter { conditions: merged_conditions.clone() },
+                                     vec![prev_node],
+                                     vec![]);
+
+    for ancestor in &first_node.borrow().ancestors {
+      ancestor.borrow_mut().remove_child(first_node.clone());
+    }
+
+    first_node.borrow_mut().ancestors.clear();
+
+    for child in &last_node.borrow().children {
+      merged_filter.borrow_mut().add_child(child.clone());
+      child.borrow_mut().add_ancestor(merged_filter.clone());
+      child.borrow_mut().remove_ancestor(last_node.clone());
+
+    }
+  }
+
+  chained_filters.clear();
+}
+
+fn to_conditions(chained_filters: &Vec<MirNodeRef>,
+                 num_columns: usize)
+                -> Vec<Option<(Operator, DataType)>> {
+
+  let mut merged_conditions = vec![None; num_columns];
+  for filter in chained_filters {
+    match filter.borrow().inner {
+      MirNodeType::Filter { ref conditions } => {
+        let i = conditions.iter().position(|c| c.is_some()).unwrap();
+        merged_conditions[i] = conditions[i].clone();
+      },
+      _ => unreachable!()
+    }
+  }
+
+  merged_conditions
 }
 
 // currently unused

--- a/src/mir/optimize.rs
+++ b/src/mir/optimize.rs
@@ -1,8 +1,79 @@
-use mir::MirQuery;
+use mir::{MirQuery, MirNodeRef, MirNodeType};
+use std::collections::HashMap;
 
 pub fn optimize(q: MirQuery) -> MirQuery {
     //remove_extraneous_projections(&mut q);
     q
+}
+
+pub fn optimize_post_reuse(q: &mut MirQuery) {
+  let chains = find_filter_chains(q);
+  println!("filter chains are {:?}", chains );
+  for chain in chains {
+    merge_filter_chain(q, chain);
+  }
+}
+
+fn merge_filter_chain(q: &mut MirQuery, chain: Vec<MirNodeRef>) {
+
+}
+
+fn find_filter_chains(q: &MirQuery) -> Vec<Vec<MirNodeRef>> {
+  let mut chains = Vec::new();
+
+  let mut current_chain = Vec::new();
+  // depth first search
+  let mut node_stack = Vec::new();
+  node_stack.extend(q.roots.iter().cloned());
+
+  let mut visited_nodes = HashMap::new();
+
+  while !node_stack.is_empty() {
+    let n = node_stack.pop().unwrap();
+    let node_name = n.borrow().versioned_name();
+    if visited_nodes.contains_key(&node_name) {
+      continue
+    }
+
+    visited_nodes.insert(node_name, true);
+
+    match n.borrow().inner {
+      MirNodeType::Filter { .. } => try_add_node_to_chain(&n, &mut current_chain, &mut chains),
+      _ => end_filter_chain(&mut current_chain, &mut chains),
+    }
+
+    for child in n.borrow().children.iter() {
+      node_stack.push(child.clone());
+    }
+  }
+
+  chains
+}
+
+fn try_add_node_to_chain(node: &MirNodeRef,
+                        current_chain: &mut Vec<MirNodeRef>,
+                        chains: &mut Vec<Vec<MirNodeRef>>) {
+  // any filter node can start a new chain
+  if current_chain.is_empty() {
+    current_chain.push(node.clone());
+  } else if node.borrow().ancestors.len() == 1 { // only nodes with a single ancestor can be added to the chain
+    current_chain.push(node.clone());
+  } else {
+    end_filter_chain(current_chain, chains);
+  }
+
+  if node.borrow().children.len() > 1 {
+    end_filter_chain(current_chain, chains);
+  }
+
+
+}
+
+fn end_filter_chain(current_chain: &mut Vec<MirNodeRef>, chains: &mut Vec<Vec<MirNodeRef>>) {
+  if !current_chain.is_empty() {
+    chains.push(current_chain.to_vec());
+    current_chain.clear();
+  }
 }
 
 // currently unused


### PR DESCRIPTION
Moving filter merge after reuse allows for more reuse opportunities for filters. Nodes in a chain are filter nodes that:
- have a single ancestor (with exception of the first node in the chain)
- have a single children (with exception of the last node in the chain)

