### PR TITLE
Correctly handles `and` and `or` predicates

### DIFF
--- a/benchmarks/hotsoup/query_blacklist.txt
+++ b/benchmarks/hotsoup/query_blacklist.txt
@@ -58,6 +58,12 @@ f5077848_d1247076f848ea67: select PaperReview.contactId, count(reviewSubmitted),
 6f0a41d1_929abaedd32ee211: select count(paperId) from PaperConflict where paperId=? and conflictType=?;
 
 ######################
+# SCHEMA v8
+
+# OR expression with query parameter
+60008016_97bd27a08a3aa46a: select count(commentId) from PaperComment where paperId=? and (forReviewers>0 or contactId=?);
+
+######################
 # SCHEMA v15
 
 # count(paperId) only projects one column, and no group by bogocol is created, but can't group by agg col

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -689,12 +689,15 @@ impl MirNode {
                                FlowNode::Existing(na) => FlowNode::Existing(na),
                         }
                     }
-                    MirNodeType::Union { .. } => {
-                        assert_eq!(self.ancestors.len(), 2);
-                        let _left = self.ancestors[0].clone();
-                        let _right = self.ancestors[1].clone();
-                        // XXX(malte): fix
-                        unimplemented!()
+                    MirNodeType::Union { ref emit } => {
+                        assert_eq!(self.ancestors.len(), emit.len());
+                        make_union_node(
+                            &name,
+                            self.columns.as_slice(),
+                            emit,
+                            self.ancestors(),
+                            mig,
+                        )
                     }
                     MirNodeType::TopK {
                         ref order,
@@ -788,12 +791,9 @@ pub enum MirNodeType {
         emit: Vec<Column>,
         literals: Vec<(String, DataType)>,
     },
-    /// emit columns left, emit columns right
-    // currently unused
-    #[allow(dead_code)]
+    /// emit columns
     Union {
-        emit_left: Vec<Column>,
-        emit_right: Vec<Column>,
+        emit: Vec<Vec<Column>>,
     },
     /// order function, group columns, k
     TopK {
@@ -1192,21 +1192,21 @@ impl Debug for MirNodeType {
             MirNodeType::Reuse { ref node } => write!(f, "Reuse [{:#?}]", node),
             MirNodeType::TopK { ref order, ref k, .. } => write!(f, "TopK [k: {}, {:?}]", k, order),
             MirNodeType::Union {
-                ref emit_left,
-                ref emit_right,
+                ref emit,
             } => {
-                let cols_left = emit_left
+                let cols = emit
                     .iter()
-                    .map(|e| e.name.clone())
+                    .map(|c| 
+                        c.iter()
+                        .map(|e| e.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                    )
                     .collect::<Vec<_>>()
-                    .join(", ");
-                let cols_right = emit_right
-                    .iter()
-                    .map(|e| e.name.clone())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                write!(f, "{} ⋃ {}", cols_left, cols_right)
-            }
+                    .join(" ⋃ ");
+
+                write!(f, "{}", cols)
+            },
         }
     }
 }
@@ -1317,6 +1317,34 @@ fn make_base_node(
     } else {
         FlowNode::New(mig.add_ingredient(name, column_names.as_slice(), base))
     }
+}
+
+fn make_union_node(
+    name: &str,
+    columns: &[Column],
+    emit: &Vec<Vec<Column>>,
+    ancestors: &[MirNodeRef],
+    mut mig: &mut Migration,
+) -> FlowNode {
+    let column_names = columns.iter().map(|c| &c.name).collect::<Vec<_>>();
+    let mut emit_column_id: HashMap<NodeIndex, Vec<usize>> = HashMap::new();
+
+    for (i, n) in ancestors.clone().iter().enumerate() {
+        let emit_cols = emit[i].iter()
+            .map(|c| n.borrow().column_id_for_column(c))
+            .collect::<Vec<_>>();
+
+        let ni = n.borrow().flow_node_addr().unwrap();
+        emit_column_id.insert(ni, emit_cols);
+        
+    }
+    let node = mig.add_ingredient(
+        String::from(name),
+        column_names.as_slice(),
+        ops::union::Union::new(emit_column_id),
+    );
+
+    FlowNode::New(node)
 }
 
 fn make_filter_node(

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1196,7 +1196,7 @@ impl Debug for MirNodeType {
             } => {
                 let cols = emit
                     .iter()
-                    .map(|c| 
+                    .map(|c|
                         c.iter()
                         .map(|e| e.name.clone())
                         .collect::<Vec<_>>()
@@ -1336,7 +1336,7 @@ fn make_union_node(
 
         let ni = n.borrow().flow_node_addr().unwrap();
         emit_column_id.insert(ni, emit_cols);
-        
+
     }
     let node = mig.add_ingredient(
         String::from(name),

--- a/src/sql/mir.rs
+++ b/src/sql/mir.rs
@@ -1299,7 +1299,7 @@ impl SqlToMirConverter {
                         };
 
                         let fns = self.make_predicate_nodes(
-                            &format!("q_{:x}_p", qg.signature().hash),
+                            &format!("q_{:x}_n{}_p", qg.signature().hash, new_node_count),
                             parent,
                             p,
                             predicate_nodes.len(),

--- a/src/sql/mir.rs
+++ b/src/sql/mir.rs
@@ -454,6 +454,29 @@ impl SqlToMirConverter {
         }
     }
 
+    fn make_union_node(
+        &mut self, 
+        name: &str,
+        ancestors: Vec<MirNodeRef>
+    ) -> MirNodeRef {
+        let mut emit: Vec<Vec<Column>> = Vec::new();
+
+        let mut cols = Vec::new();
+        for ancestor in ancestors.iter() {
+            cols = ancestor.borrow().columns().iter().cloned().collect();
+            emit.push(cols.clone());
+        }
+
+        MirNode::new(
+            name,
+            self.schema_version,
+            cols,
+            MirNodeType::Union { emit },
+            ancestors.clone(),
+            vec![],
+        )
+    }
+
     fn make_filter_nodes(
         &mut self,
         name: &str,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -732,7 +732,7 @@ mod tests {
             &[&Column::from("users.name")],
         );
         // filter node
-        let filter = get_node(&inc, &mig, &format!("q_{:x}_n0_f0", qid));
+        let filter = get_node(&inc, &mig, &format!("q_{:x}_n0_p0_f0", qid));
         assert_eq!(filter.fields(), &["id", "name"]);
         assert_eq!(filter.description(), format!("σ[f0 = 42]"));
         // leaf view node

--- a/src/sql/query_graph.rs
+++ b/src/sql/query_graph.rs
@@ -295,7 +295,7 @@ fn classify_conditionals(
             match ct.operator {
                 Operator::And => {
                     for (t, ces) in new_local {
-                        assert!(ces.len() <= 2, "can only combine less than 2 ConditionExpression's");
+                        assert!(ces.len() <= 2, "can only combine two or fewer ConditionExpression's");
                         if ces.len() == 2 {
                             let new_ce = ConditionExpression::LogicalOp(ConditionTree {
                                 operator: Operator::And,

--- a/src/sql/reuse.rs
+++ b/src/sql/reuse.rs
@@ -390,21 +390,21 @@ mod tests {
             right: Box::new(Base(Literal(Literal::Integer(80.into())))),
         });
 
-        // a < 20 or a > 80
+        // a < 20 or a > 60
         let cp1 = LogicalOp(ConditionTree {
             left: Box::new(pa.clone()),
             right: Box::new(pb.clone()),
             operator: Operator::Or
         });
 
-        // a < 10 or a > 60
+        // a < 10 or a > 80
         let cp2 = LogicalOp(ConditionTree {
             left: Box::new(pc),
             right: Box::new(pd),
             operator: Operator::Or
         });
 
-        // a < 80 or a > 20
+        // a > 60 or a < 20
         let cp3 = LogicalOp(ConditionTree {
             left: Box::new(pb),
             right: Box::new(pa),

--- a/tests/finkelstein82.txt
+++ b/tests/finkelstein82.txt
@@ -20,4 +20,4 @@ SELECT p.name, c.corpname, c.location FROM people AS p, companies AS c WHERE p.e
 SELECT p.name, s.schoolname FROM people AS p, companies AS c, schools AS s WHERE p.experience >= 20 AND p.age <= 65 AND p.employer = c.corpname AND c.location = 'NY' AND c.earnings > 500000 AND p.education = s.schoolname AND s.level = 'university';
 
 # Q6
-#SELECT p.name, c.corpname, c.location FROM people AS p, companies AS c, companies AS c1 WHERE p.experience >= 20 AND p.age <= 65 AND p.employer = c.corpname AND ( c.location = 'NY' OR c.location = 'CA' ) AND c.earnings > 500000 AND p.name = c1.president AND c1.president = 'Smith' AND c1.business = 'manufacturing';
+SELECT p.name, c.corpname, c.location FROM people AS p, companies AS c, companies AS c1 WHERE p.experience >= 20 AND p.age <= 65 AND p.employer = c.corpname AND ( c.location = 'NY' OR c.location = 'CA' ) AND c.earnings > 500000 AND p.name = c1.president AND c1.president = 'Smith' AND c1.business = 'manufacturing';


### PR DESCRIPTION
Previously, we incorrectly handled `or` predicates and only allowed for one level of nested predicates. 

Now, we support multiple levels of nesting and `and` predicates are constructed by chaining the lefts-side and the right-side nodes, while `or` predicates are constructed by unioning the lefts-side and the right-side nodes.

There are limitations to the way we currently handle `or` predicates, more specifically we **don't** support:
-  `or` expressions with predicates with placeholder parameters, because these expressions are meaningless in the Soup context.
- `or` expressions with join predicates.
- `or` expressions between different tables (e.g ```table1.x = 1 OR table2.y= 42```).