### PR TITLE
Add other reuse algorithm options

### DIFF
--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -229,7 +229,6 @@ impl SqlIncorporator {
                 reuse_candidates
             );
 
-            // TODO(malte): score reuse candidates
             let mir_queries: Vec<MirQuery> = reuse_candidates.iter()
             .map(|c| {
                 self.query_graphs[&c.1.signature().hash].1.clone()
@@ -375,7 +374,7 @@ impl SqlIncorporator {
         for m in reuse_mirs {
             let res =
                 merge_mir_for_queries(&self.log, &reused_mir, &m);
-            reused_mir = res.0.clone();
+            reused_mir = res.0;
             if res.1 > num_reused_nodes { num_reused_nodes = res.1; }
         }
 

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -372,9 +372,9 @@ impl SqlIncorporator {
         // compare to existing query MIR and reuse prefix
         let mut reused_mir = new_opt_mir.clone();
         let mut num_reused_nodes = 0;
-        for extend_mir in reuse_mirs {
+        for m in reuse_mirs {
             let res =
-                merge_mir_for_queries(&self.log, &reused_mir, &extend_mir);
+                merge_mir_for_queries(&self.log, &reused_mir, &m);
             reused_mir = res.0.clone();
             if res.1 > num_reused_nodes { num_reused_nodes = res.1; }
         }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -12,7 +12,7 @@ use nom_sql::parser as sql_parser;
 use nom_sql::{Column, SqlQuery};
 use nom_sql::SelectStatement;
 use self::mir::{MirNodeRef, MirQuery, SqlToMirConverter};
-use self::reuse::{ReuseType, ReuseConfig};
+use self::reuse::ReuseConfig;
 use sql::query_graph::{QueryGraph, to_query_graph};
 
 use slog;
@@ -35,7 +35,7 @@ pub struct QueryFlowParts {
 #[derive(Clone, Debug)]
 enum QueryGraphReuse {
     ExactMatch(MirNodeRef),
-    ExtendExisting(MirQuery),
+    ExtendExisting(Vec<MirQuery>),
     ReaderOntoExisting(MirNodeRef, Vec<Column>),
     None,
 }

--- a/src/sql/query_signature.rs
+++ b/src/sql/query_signature.rs
@@ -39,8 +39,26 @@ impl<'a> QuerySignature<'a> {
         if !self.relations.is_subset(&other.relations) {
             return false;
         }
+
         // 2) either the same attributes as in `other`, or a subset of them
         if !self.attributes.is_subset(&other.attributes) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // Checks if a query is a weak generalization of the other by analyzing their
+    // relations.
+    pub fn is_weak_generalization_of(&self, other: &QuerySignature) -> bool {
+        // if the queries are the same, they are (non-strict) generalizations of each other
+        if self.hash == other.hash {
+            return true;
+        }
+
+        // to be a generalization, we must have
+        // 1) either the same relations as in `other`, or a subset of them
+        if !self.relations.is_subset(&other.relations) {
             return false;
         }
 

--- a/src/sql/query_signature.rs
+++ b/src/sql/query_signature.rs
@@ -58,7 +58,7 @@ impl<'a> QuerySignature<'a> {
 
         // to be a generalization, we must have
         // 1) either the same relations as in `other`, or a subset of them
-        if !self.relations.is_subset(&other.relations) {
+        if self.relations.is_disjoint(&other.relations) {
             return false;
         }
 

--- a/src/sql/reuse/finkelstein.rs
+++ b/src/sql/reuse/finkelstein.rs
@@ -26,9 +26,17 @@ impl ReuseConfiguration for Finkelstein {
             }
         }
 
-        reuse_candidates
+        if reuse_candidates.len() > 0 {
+            vec![Self::choose_best_option(reuse_candidates)]
+        }
+        else {
+            reuse_candidates
+        }
     }
 
+}
+
+impl Finkelstein {
     fn choose_best_option<'a>(options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph) {
         let mut best_choice = None;
         let mut best_score = 0;
@@ -59,9 +67,7 @@ impl ReuseConfiguration for Finkelstein {
 
         best_choice.unwrap()
     }
-}
 
-impl Finkelstein {
     fn check_compatibility(new_qg: &QueryGraph, existing_qg: &QueryGraph) -> Option<ReuseType> {
         // 1. NQG's nodes is subset of EQG's nodes
         // -- already established via signature check

--- a/src/sql/reuse/finkelstein.rs
+++ b/src/sql/reuse/finkelstein.rs
@@ -8,6 +8,11 @@ use std::collections::HashMap;
 
 pub struct Finkelstein;
 
+/// Finkelstein reuse algorithm.
+/// This algorithm checks if any existing query graphs are generalizations
+/// of the query graph of the new query being added.
+/// For Soup's purpose this algorithm is sometimes too strict as it only
+/// considers reuse of final materializations, not intermediate ones.
 impl ReuseConfiguration for Finkelstein {
     fn reuse_candidates<'a>(qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)>{
         let mut reuse_candidates = Vec::new();
@@ -154,7 +159,7 @@ impl Finkelstein {
             }
         }
 
-        // we don't need to check projected columsn to reuse a prefix of the query
+        // we don't need to check projected columns to reuse a prefix of the query
         return Some(ReuseType::DirectExtension);
 
         // 5. Consider projected columns

--- a/src/sql/reuse/finkelstein.rs
+++ b/src/sql/reuse/finkelstein.rs
@@ -1,0 +1,195 @@
+use sql::reuse::helpers::predicate_implication::complex_predicate_implies;
+use sql::reuse::{ReuseConfiguration, ReuseType};
+use sql::query_graph::{QueryGraph, QueryGraphEdge};
+use mir::MirQuery;
+
+use std::vec::Vec;
+use std::collections::HashMap;
+
+pub struct Finkelstein;
+
+impl ReuseConfiguration for Finkelstein {
+    fn reuse_candidates<'a>(qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)>{
+        let mut reuse_candidates = Vec::new();
+        for &(ref existing_qg, _) in query_graphs.values() {
+            if existing_qg
+                .signature()
+                .is_generalization_of(&qg.signature())
+            {
+                match Self::check_compatibility(&qg, existing_qg) {
+                    Some(reuse) => {
+                        // QGs are compatible, we can reuse `existing_qg` as part of `qg`!
+                        reuse_candidates.push((reuse, existing_qg));
+                    }
+                    None => (),
+                }
+            }
+        }
+
+        reuse_candidates
+    }
+
+    fn choose_best_option<'a>(options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph) {
+        let mut best_choice = None;
+        let mut best_score = 0;
+
+        for (o, qg) in options {
+            let mut score = 0;
+
+            // crude scoring: direct extension always preferrable over backjoins; reusing larger
+            // queries is also preferrable as they are likely to cover a larger fraction of the new
+            // query's nodes. Edges (group by, join) count for more than extra relations.
+            match o {
+                ReuseType::DirectExtension => {
+                    score += 2 * qg.relations.len() + 4 * qg.edges.len() + 10;
+                }
+                ReuseType::BackjoinRequired(_) => {
+                    score += qg.relations.len() + 3 * qg.edges.len();
+                }
+                _ => unreachable!()
+            }
+
+            if score > best_score {
+                best_score = score;
+                best_choice = Some((o, qg));
+            }
+        }
+
+        assert!(best_score > 0);
+
+        best_choice.unwrap()
+    }
+}
+
+impl Finkelstein {
+    fn check_compatibility(new_qg: &QueryGraph, existing_qg: &QueryGraph) -> Option<ReuseType> {
+        // 1. NQG's nodes is subset of EQG's nodes
+        // -- already established via signature check
+        // 2. NQG's attributes is subset of NQG's edges
+        // -- already established via signature check
+        assert!(
+            existing_qg
+                .signature()
+                .is_generalization_of(&new_qg.signature())
+        );
+
+        // 3. NQC's edges are superset of EQG's
+        //    (N.B.: this does not yet consider the relationships of the edge predicates; we do that
+        //    below in the next step.)
+        for e in &existing_qg.edges {
+            if !new_qg.edges.contains_key(e.0) {
+                return None;
+            }
+        }
+
+        // 4. NQG's predicates imply EQG's
+        //   4a. on nodes
+        for (name, ex_qgn) in &existing_qg.relations {
+            let new_qgn = &new_qg.relations[name];
+
+            // iterate over predicates and ensure that each matching one on the existing QG is implied
+            // by the new one
+            for ep in &ex_qgn.predicates {
+                let mut matched = false;
+
+                for np in &new_qgn.predicates {
+                    if complex_predicate_implies(np, ep) {
+                        matched = true;
+                        break
+                    }
+                }
+                if !matched {
+                    // We found no matching predicate for np, so we give up now.
+                    // trace!(log, "Failed: no matching predicate for {:#?}", ep);
+                    return None;
+                }
+            }
+        }
+        //   4b. on edges
+        for (srcdst, ex_qge) in &existing_qg.edges {
+            let new_qge = &new_qg.edges[srcdst];
+
+            match *ex_qge {
+                QueryGraphEdge::GroupBy(ref ex_columns) => {
+                    match *new_qge {
+                        QueryGraphEdge::GroupBy(ref new_columns) => {
+                            // GroupBy implication holds if the new QG groups by the same columns as
+                            // the original one, or by a *superset* (as we can always apply more
+                            // grouped operatinos on top of earlier ones)
+                            if new_columns.len() < ex_columns.len() {
+                                // more columns in existing QG's GroupBy, so we're done
+                                return None;
+                            }
+                            for ex_col in ex_columns {
+                                // EQG groups by a column that we don't group by, so we can't reuse
+                                if !new_columns.contains(ex_col) {
+                                    return None;
+                                }
+                            }
+                        }
+                        // If there is no matching GroupBy edge, we cannot reuse
+                        _ => return None,
+                    }
+                }
+                QueryGraphEdge::Join(_) => {
+                    match *new_qge {
+                        QueryGraphEdge::Join(_) => {}
+                        // If there is no matching Join edge, we cannot reuse
+                        _ => return None,
+                    }
+                }
+                QueryGraphEdge::LeftJoin(_) => {
+                    match *new_qge {
+                        QueryGraphEdge::LeftJoin(_) => {}
+                        // If there is no matching LeftJoin edge, we cannot reuse
+                        _ => return None,
+                    }
+                }
+            }
+        }
+
+        // we don't need to check projected columsn to reuse a prefix of the query
+        return Some(ReuseType::DirectExtension);
+
+        // 5. Consider projected columns
+        //   5a. NQG projects a subset of EQG's edges --> can use directly
+        // for (name, ex_qgn) in &existing_qg.relations {
+        //     let new_qgn = &new_qg.relations[name];
+
+        //     // does EQG already have *all* the columns we project?
+        //     let all_projected = new_qgn
+        //         .columns
+        //         .iter()
+        //         .all(|nc| ex_qgn.columns.contains(nc));
+        //     if all_projected {
+        //         // if so, super -- we can extend directly
+        //         return Some(ReuseType::DirectExtension);
+        //     } else {
+        //         if name == "computed_columns" {
+        //             // NQG has some extra columns, and they're computed ones (i.e., grouped/function
+        //             // columns). We can recompute those, but not via a backjoin.
+        //             // TODO(malte): be cleverer about this situation
+        //             return None;
+        //         }
+
+        //         // find the extra columns in the EQG to identify backjoins required
+        //         let backjoin_tables: Vec<_> = new_qgn
+        //             .columns
+        //             .iter()
+        //             .filter(|nc| !ex_qgn.columns.contains(nc) && nc.table.is_some())
+        //             .map(|c| Table::from(c.table.as_ref().unwrap().as_str()))
+        //             .collect();
+
+        //         if backjoin_tables.len() > 0 {
+        //             return Some(ReuseType::BackjoinRequired(backjoin_tables));
+        //         } else {
+        //             panic!("expected to find some backjoin tables!");
+        //         }
+        //     }
+        // }
+        // XXX(malte):  5b. NQG projects a superset of EQG's edges --> need backjoin
+
+        // XXX(malte): should this be a positive? If so, what?
+        // None
+    }
+}

--- a/src/sql/reuse/full.rs
+++ b/src/sql/reuse/full.rs
@@ -6,7 +6,9 @@ use std::vec::Vec;
 use std::collections::HashMap;
 
 
+/// Full reuse algorithm
 /// Implementation of reuse algorithm that checks all available reuse options.
+/// This algorithm yields maximum reuse, since it checks all possible options.
 pub struct Full;
 
 impl ReuseConfiguration for Full {

--- a/src/sql/reuse/full.rs
+++ b/src/sql/reuse/full.rs
@@ -1,0 +1,16 @@
+use sql::reuse::{ReuseConfiguration, ReuseType};
+use sql::query_graph::QueryGraph;
+use mir::MirQuery;
+
+use std::vec::Vec;
+use std::collections::HashMap;
+
+
+/// Implementation of reuse algorithm that checks all available reuse options.
+pub struct Full;
+
+impl ReuseConfiguration for Full {
+    fn reuse_candidates<'a>(_qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)>{
+        query_graphs.values().map(|c| (ReuseType::DirectExtension, &c.0)).collect()
+    }
+}

--- a/src/sql/reuse/helpers/mod.rs
+++ b/src/sql/reuse/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod predicate_implication;

--- a/src/sql/reuse/helpers/predicate_implication.rs
+++ b/src/sql/reuse/helpers/predicate_implication.rs
@@ -1,16 +1,5 @@
-use nom_sql::{ConditionBase, ConditionExpression, ConditionTree, Literal, Operator, Table};
-use sql::query_graph::{QueryGraph, QueryGraphEdge};
+use nom_sql::{ConditionBase, ConditionExpression, ConditionTree, Literal, Operator};
 use nom_sql::ConditionExpression::*;
-
-use std::str;
-use std::vec::Vec;
-
-#[derive(Clone, Debug)]
-pub enum ReuseType {
-    DirectExtension,
-    #[allow(dead_code)]
-    BackjoinRequired(Vec<Table>),
-}
 
 fn direct_elimination(op1: &Operator, op2: &Operator) -> Option<Operator> {
     match *op1 {
@@ -96,7 +85,7 @@ where
 }
 
 /// Direct elimination for complex predicates with nested `and` and `or` expressions
-fn complex_predicate_implies(np: &ConditionExpression, ep: &ConditionExpression) -> bool {
+pub fn complex_predicate_implies(np: &ConditionExpression, ep: &ConditionExpression) -> bool {
     match *ep {
         LogicalOp(ref ect) => {
             match *np {
@@ -167,167 +156,6 @@ fn predicate_implies(np: &ConditionTree, ep: &ConditionTree) -> bool {
         }
         _ => panic!("right-hand side of predicate must currently be literal"),
     }
-}
-
-pub fn check_compatibility(new_qg: &QueryGraph, existing_qg: &QueryGraph) -> Option<ReuseType> {
-    // 1. NQG's nodes is subset of EQG's nodes
-    // -- already established via signature check
-    // 2. NQG's attributes is subset of NQG's edges
-    // -- already established via signature check
-    assert!(
-        existing_qg
-            .signature()
-            .is_generalization_of(&new_qg.signature())
-    );
-
-    // 3. NQC's edges are superset of EQG's
-    //    (N.B.: this does not yet consider the relationships of the edge predicates; we do that
-    //    below in the next step.)
-    for e in &existing_qg.edges {
-        if !new_qg.edges.contains_key(e.0) {
-            return None;
-        }
-    }
-
-    // 4. NQG's predicates imply EQG's
-    //   4a. on nodes
-    for (name, ex_qgn) in &existing_qg.relations {
-        let new_qgn = &new_qg.relations[name];
-
-        // iterate over predicates and ensure that each matching one on the existing QG is implied
-        // by the new one
-        for ep in &ex_qgn.predicates {
-            let mut matched = false;
-
-            for np in &new_qgn.predicates {
-                if complex_predicate_implies(np, ep) {
-                    matched = true;
-                    break
-                }
-            }
-            if !matched {
-                // We found no matching predicate for np, so we give up now.
-                // trace!(log, "Failed: no matching predicate for {:#?}", ep);
-                return None;
-            }
-        }
-    }
-    //   4b. on edges
-    for (srcdst, ex_qge) in &existing_qg.edges {
-        let new_qge = &new_qg.edges[srcdst];
-
-        match *ex_qge {
-            QueryGraphEdge::GroupBy(ref ex_columns) => {
-                match *new_qge {
-                    QueryGraphEdge::GroupBy(ref new_columns) => {
-                        // GroupBy implication holds if the new QG groups by the same columns as
-                        // the original one, or by a *superset* (as we can always apply more
-                        // grouped operatinos on top of earlier ones)
-                        if new_columns.len() < ex_columns.len() {
-                            // more columns in existing QG's GroupBy, so we're done
-                            return None;
-                        }
-                        for ex_col in ex_columns {
-                            // EQG groups by a column that we don't group by, so we can't reuse
-                            if !new_columns.contains(ex_col) {
-                                return None;
-                            }
-                        }
-                    }
-                    // If there is no matching GroupBy edge, we cannot reuse
-                    _ => return None,
-                }
-            }
-            QueryGraphEdge::Join(_) => {
-                match *new_qge {
-                    QueryGraphEdge::Join(_) => {}
-                    // If there is no matching Join edge, we cannot reuse
-                    _ => return None,
-                }
-            }
-            QueryGraphEdge::LeftJoin(_) => {
-                match *new_qge {
-                    QueryGraphEdge::LeftJoin(_) => {}
-                    // If there is no matching LeftJoin edge, we cannot reuse
-                    _ => return None,
-                }
-            }
-        }
-    }
-
-    // we don't need to check projected columsn to reuse a prefix of the query
-    return Some(ReuseType::DirectExtension);
-
-    // 5. Consider projected columns
-    //   5a. NQG projects a subset of EQG's edges --> can use directly
-    // for (name, ex_qgn) in &existing_qg.relations {
-    //     let new_qgn = &new_qg.relations[name];
-
-    //     // does EQG already have *all* the columns we project?
-    //     let all_projected = new_qgn
-    //         .columns
-    //         .iter()
-    //         .all(|nc| ex_qgn.columns.contains(nc));
-    //     if all_projected {
-    //         // if so, super -- we can extend directly
-    //         return Some(ReuseType::DirectExtension);
-    //     } else {
-    //         if name == "computed_columns" {
-    //             // NQG has some extra columns, and they're computed ones (i.e., grouped/function
-    //             // columns). We can recompute those, but not via a backjoin.
-    //             // TODO(malte): be cleverer about this situation
-    //             return None;
-    //         }
-
-    //         // find the extra columns in the EQG to identify backjoins required
-    //         let backjoin_tables: Vec<_> = new_qgn
-    //             .columns
-    //             .iter()
-    //             .filter(|nc| !ex_qgn.columns.contains(nc) && nc.table.is_some())
-    //             .map(|c| Table::from(c.table.as_ref().unwrap().as_str()))
-    //             .collect();
-
-    //         if backjoin_tables.len() > 0 {
-    //             return Some(ReuseType::BackjoinRequired(backjoin_tables));
-    //         } else {
-    //             panic!("expected to find some backjoin tables!");
-    //         }
-    //     }
-    // }
-    // XXX(malte):  5b. NQG projects a superset of EQG's edges --> need backjoin
-
-    // XXX(malte): should this be a positive? If so, what?
-    // None
-}
-
-pub fn choose_best_option(options: Vec<(ReuseType, &QueryGraph)>) -> (ReuseType, &QueryGraph) {
-    let mut best_choice = None;
-    let mut best_score = 0;
-
-    for (o, qg) in options {
-        let mut score = 0;
-
-        // crude scoring: direct extension always preferrable over backjoins; reusing larger
-        // queries is also preferrable as they are likely to cover a larger fraction of the new
-        // query's nodes. Edges (group by, join) count for more than extra relations.
-        match o {
-            ReuseType::DirectExtension => {
-                score += 2 * qg.relations.len() + 4 * qg.edges.len() + 10;
-            }
-            ReuseType::BackjoinRequired(_) => {
-                score += qg.relations.len() + 3 * qg.edges.len();
-            }
-        }
-
-        if score > best_score {
-            best_score = score;
-            best_choice = Some((o, qg));
-        }
-    }
-
-    assert!(best_score > 0);
-
-    best_choice.unwrap()
 }
 
 #[cfg(test)]
@@ -532,3 +360,4 @@ mod tests {
         assert!(complex_predicate_implies(&cp1, &pb));
     }
 }
+

--- a/src/sql/reuse/mod.rs
+++ b/src/sql/reuse/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 mod finkelstein;
 mod weak;
+mod all;
 mod helpers;
 
 #[derive(Clone, Debug)]
@@ -20,6 +21,7 @@ pub enum ReuseType {
 enum ReuseConfigType {
     Finkelstein,
     Weak,
+    All,
 }
 
 const REUSE_CONFIG: ReuseConfigType = ReuseConfigType::Finkelstein;
@@ -33,13 +35,7 @@ impl ReuseConfig {
         match self.config {
             ReuseConfigType::Finkelstein => finkelstein::Finkelstein::reuse_candidates(qg, query_graphs),
             ReuseConfigType::Weak => weak::Weak::reuse_candidates(qg, query_graphs),
-        }
-    }
-
-    pub fn choose_best_option<'a>(&self, options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph) {
-         match self.config {
-            ReuseConfigType::Finkelstein => finkelstein::Finkelstein::choose_best_option(options),
-            ReuseConfigType::Weak => weak::Weak::choose_best_option(options)
+            ReuseConfigType::All => all::All::reuse_candidates(qg, query_graphs),
         }
     }
 
@@ -47,6 +43,13 @@ impl ReuseConfig {
         match REUSE_CONFIG {
             ReuseConfigType::Finkelstein => ReuseConfig::finkelstein(),
             ReuseConfigType::Weak => ReuseConfig::weak(),
+            ReuseConfigType::All => ReuseConfig::all(),
+        }
+    }
+
+    pub fn all() -> ReuseConfig {
+        ReuseConfig {
+            config: ReuseConfigType::All,
         }
     }
 
@@ -65,6 +68,4 @@ impl ReuseConfig {
 
 pub trait ReuseConfiguration {
     fn reuse_candidates<'a>(qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)>;
-
-    fn choose_best_option<'a>(options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph);
 }

--- a/src/sql/reuse/mod.rs
+++ b/src/sql/reuse/mod.rs
@@ -24,6 +24,7 @@ enum ReuseConfigType {
     Full,
 }
 
+// TODO(larat): make this a dynamic option
 const REUSE_CONFIG: ReuseConfigType = ReuseConfigType::Finkelstein;
 
 pub struct ReuseConfig {

--- a/src/sql/reuse/mod.rs
+++ b/src/sql/reuse/mod.rs
@@ -6,8 +6,8 @@ use std::vec::Vec;
 use std::collections::HashMap;
 
 mod finkelstein;
-mod weak;
-mod all;
+mod relaxed;
+mod full;
 mod helpers;
 
 #[derive(Clone, Debug)]
@@ -20,8 +20,8 @@ pub enum ReuseType {
 
 enum ReuseConfigType {
     Finkelstein,
-    Weak,
-    All,
+    Relaxed,
+    Full,
 }
 
 const REUSE_CONFIG: ReuseConfigType = ReuseConfigType::Finkelstein;
@@ -34,22 +34,22 @@ impl ReuseConfig {
     pub fn reuse_candidates<'a>(&self, qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)> {
         match self.config {
             ReuseConfigType::Finkelstein => finkelstein::Finkelstein::reuse_candidates(qg, query_graphs),
-            ReuseConfigType::Weak => weak::Weak::reuse_candidates(qg, query_graphs),
-            ReuseConfigType::All => all::All::reuse_candidates(qg, query_graphs),
+            ReuseConfigType::Relaxed => relaxed::Relaxed::reuse_candidates(qg, query_graphs),
+            ReuseConfigType::Full => full::Full::reuse_candidates(qg, query_graphs),
         }
     }
 
     pub fn default() -> ReuseConfig {
         match REUSE_CONFIG {
             ReuseConfigType::Finkelstein => ReuseConfig::finkelstein(),
-            ReuseConfigType::Weak => ReuseConfig::weak(),
-            ReuseConfigType::All => ReuseConfig::all(),
+            ReuseConfigType::Relaxed => ReuseConfig::relaxed(),
+            ReuseConfigType::Full => ReuseConfig::full(),
         }
     }
 
-    pub fn all() -> ReuseConfig {
+    pub fn full() -> ReuseConfig {
         ReuseConfig {
-            config: ReuseConfigType::All,
+            config: ReuseConfigType::Full,
         }
     }
 
@@ -59,9 +59,9 @@ impl ReuseConfig {
         }
     }
 
-    pub fn weak() -> ReuseConfig {
+    pub fn relaxed() -> ReuseConfig {
         ReuseConfig {
-            config: ReuseConfigType::Weak,
+            config: ReuseConfigType::Relaxed,
         }
     }
 }

--- a/src/sql/reuse/mod.rs
+++ b/src/sql/reuse/mod.rs
@@ -1,0 +1,70 @@
+use nom_sql::Table;
+use sql::query_graph::QueryGraph;
+use mir::MirQuery;
+
+use std::vec::Vec;
+use std::collections::HashMap;
+
+mod finkelstein;
+mod weak;
+mod helpers;
+
+#[derive(Clone, Debug)]
+pub enum ReuseType {
+    DirectExtension,
+    PrefixReuse,
+    #[allow(dead_code)]
+    BackjoinRequired(Vec<Table>),
+}
+
+enum ReuseConfigType {
+    Finkelstein,
+    Weak,
+}
+
+const REUSE_CONFIG: ReuseConfigType = ReuseConfigType::Finkelstein;
+
+pub struct ReuseConfig {
+    config: ReuseConfigType,
+}
+
+impl ReuseConfig {
+    pub fn reuse_candidates<'a>(&self, qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)> {
+        match self.config {
+            ReuseConfigType::Finkelstein => finkelstein::Finkelstein::reuse_candidates(qg, query_graphs),
+            ReuseConfigType::Weak => weak::Weak::reuse_candidates(qg, query_graphs),
+        }
+    }
+
+    pub fn choose_best_option<'a>(&self, options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph) {
+         match self.config {
+            ReuseConfigType::Finkelstein => finkelstein::Finkelstein::choose_best_option(options),
+            ReuseConfigType::Weak => weak::Weak::choose_best_option(options)
+        }
+    }
+
+    pub fn default() -> ReuseConfig {
+        match REUSE_CONFIG {
+            ReuseConfigType::Finkelstein => ReuseConfig::finkelstein(),
+            ReuseConfigType::Weak => ReuseConfig::weak(),
+        }
+    }
+
+    pub fn finkelstein() -> ReuseConfig {
+        ReuseConfig {
+            config: ReuseConfigType::Finkelstein,
+        }
+    }
+
+    pub fn weak() -> ReuseConfig {
+        ReuseConfig {
+            config: ReuseConfigType::Weak,
+        }
+    }
+}
+
+pub trait ReuseConfiguration {
+    fn reuse_candidates<'a>(qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)>;
+
+    fn choose_best_option<'a>(options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph);
+}

--- a/src/sql/reuse/relaxed.rs
+++ b/src/sql/reuse/relaxed.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 use std::collections::HashMap;
 
 
-/// Implementation of reuse algorithm with Relaxeder constraints than Finkelstein.
+/// Implementation of reuse algorithm with relaxed constraints.
 /// While Finkelstein checks if queries are compatible for direct extension,
 /// this algorithm considers the possibility of reuse of internal views.
 /// For example, given the queries:

--- a/src/sql/reuse/relaxed.rs
+++ b/src/sql/reuse/relaxed.rs
@@ -61,6 +61,15 @@ impl Relaxed {
 
         // Check if the queries are join compatible -- if the new query
         // performs a superset of the joins in the existing query.
+
+        // TODO 1: this currently only checks that the joins use the same
+        // tables. some possible improvements are:
+        // 1) relaxing to fail only on non-disjoint join sets
+        // 2) constraining to also check implication of join predicates
+
+        // TODO 2: malte's suggestion of possibly reuse LeftJoin as a
+        // plain Join by simply adding a filter that discards rows with
+        // NULLs in the right side columns
         for (srcdst, ex_qge) in &existing_qg.edges {
             match *ex_qge {
                 QueryGraphEdge::Join(_) => {
@@ -141,7 +150,9 @@ impl Relaxed {
             }
         }
 
-        // we don't need to check projected columns to reuse a prefix of the query
+        // projected columns don't influence the reuse opportunities in this case, since
+        // we are only trying to reuse the query partially, not completely extending it.
+
         return Some(ReuseType::DirectExtension);
     }
 }

--- a/src/sql/reuse/weak.rs
+++ b/src/sql/reuse/weak.rs
@@ -1,0 +1,179 @@
+use sql::reuse::helpers::predicate_implication::complex_predicate_implies;
+use sql::reuse::{ReuseConfiguration, ReuseType};
+use sql::query_graph::{QueryGraph, QueryGraphEdge};
+use mir::MirQuery;
+
+use std::vec::Vec;
+use std::collections::HashMap;
+
+
+/// Implementation of reuse algorithm with weaker constraints than Finkelstein.
+/// While Finkelstein checks if queries are compatible for direct extension,
+/// this algorithm considers the possibility of reuse of internal views.
+/// For example, given the queries:
+/// 1) select * from Paper, PaperReview where Paper.paperId = PaperReview.paperId and PaperReview.reviewType = 1;
+/// 2) select * from Paper, PaperReview where Paper.paperId = PaperReview.paperId;
+///
+/// Finkelstein reuse would be conditional on the order the queries are added,
+/// since 1) is a direct extension of 2), but not the other way around.
+///
+/// This weak version of the reuse algorithm considers cases where a query might
+/// reuse just a prefix of another. First, it checks if the queries perform the
+/// same joins, then it checks predicate implication and at last, checks group
+/// by compatibility.
+/// If all checks pass, them the algorithm works like Finkelstein and the query
+/// is a direct extension of the other. However, if not all, but at least one
+/// check passes, then the algorithm returns that the queries have a prefix in
+/// common.
+pub struct Weak;
+
+impl ReuseConfiguration for Weak {
+    fn reuse_candidates<'a>(qg: &QueryGraph, query_graphs: &'a HashMap<u64, (QueryGraph, MirQuery)>) -> Vec<(ReuseType, &'a QueryGraph)>{
+        let mut reuse_candidates = Vec::new();
+        for &(ref existing_qg, _) in query_graphs.values() {
+            if existing_qg
+                .signature()
+                .is_weak_generalization_of(&qg.signature())
+            {
+                match Self::check_compatibility(&qg, existing_qg) {
+                    Some(reuse) => {
+                        // QGs are compatible, we can reuse `existing_qg` as part of `qg`!
+                        reuse_candidates.push((reuse, existing_qg));
+                    }
+                    None => (),
+                }
+            }
+        }
+
+        reuse_candidates
+    }
+
+    fn choose_best_option<'a>(options: Vec<(ReuseType, &'a QueryGraph)>) -> (ReuseType, &'a QueryGraph) {
+        let mut best_choice = None;
+        let mut best_score = 0;
+
+        for (o, qg) in options {
+            let mut score = 0;
+
+            // crude scoring: direct extension always preferrable over backjoins; reusing larger
+            // queries is also preferrable as they are likely to cover a larger fraction of the new
+            // query's nodes. Edges (group by, join) count for more than extra relations.
+            match o {
+                ReuseType::DirectExtension => {
+                    score += 2 * qg.relations.len() + 4 * qg.edges.len() + 1000;
+                }
+                ReuseType::PrefixReuse => {
+                    score += 2 * qg.relations.len() + 4 * qg.edges.len() + 500;
+                }
+                ReuseType::BackjoinRequired(_) => {
+                    score += qg.relations.len() + 3 * qg.edges.len();
+                }
+            }
+
+            if score > best_score {
+                best_score = score;
+                best_choice = Some((o, qg));
+            }
+        }
+
+        assert!(best_score > 0);
+
+        best_choice.unwrap()
+    }
+}
+
+impl Weak {
+    fn check_compatibility(new_qg: &QueryGraph, existing_qg: &QueryGraph) -> Option<ReuseType> {
+        // 1. NQG's nodes is subset of EQG's nodes
+        // -- already established via signature check
+        assert!(
+            existing_qg
+                .signature()
+                .is_weak_generalization_of(&new_qg.signature())
+        );
+
+        // Check if the queries are join compatible -- if the new query
+        // performs a superset of the joins in the existing query.
+        for (srcdst, ex_qge) in &existing_qg.edges {
+            match *ex_qge {
+                QueryGraphEdge::Join(_) => {
+                    if !new_qg.edges.contains_key(srcdst) { return None; }
+                    let new_qge = &new_qg.edges[srcdst];
+                    match *new_qge {
+                        QueryGraphEdge::Join(_) => {}
+                        // If there is no matching Join edge, we cannot reuse
+                        _ => return None,
+                    }
+                }
+                QueryGraphEdge::LeftJoin(_) => {
+                    if !new_qg.edges.contains_key(srcdst) { return None; }
+                    let new_qge = &new_qg.edges[srcdst];
+                    match *new_qge {
+                        QueryGraphEdge::LeftJoin(_) => {}
+                        // If there is no matching LeftJoin edge, we cannot reuse
+                        _ => return None,
+                    }
+                }
+                _ => continue
+            }
+        }
+
+        // Checks group by compatibility between queries.
+        for (srcdst, ex_qge) in &existing_qg.edges {
+            match *ex_qge {
+                QueryGraphEdge::GroupBy(ref ex_columns) => {
+                    if !new_qg.edges.contains_key(srcdst) { return Some(ReuseType::PrefixReuse); }
+                    let new_qge = &new_qg.edges[srcdst];
+                    match *new_qge {
+                        QueryGraphEdge::GroupBy(ref new_columns) => {
+                            // GroupBy implication holds if the new QG groups by the same columns as
+                            // the original one, or by a *superset* (as we can always apply more
+                            // grouped operatinos on top of earlier ones)
+                            if new_columns.len() < ex_columns.len() {
+                                // more columns in existing QG's GroupBy, so we're done
+                                // however, we can still reuse joins and predicates.
+                                return Some(ReuseType::PrefixReuse);
+                            }
+                            for ex_col in ex_columns {
+                                // EQG groups by a column that we don't group by, so we can't reuse
+                                // the group by nodes, but we can still reuse joins and predicates.
+                                if !new_columns.contains(ex_col) {
+                                    return Some(ReuseType::PrefixReuse);
+                                }
+                            }
+                        }
+                        // If there is no matching GroupBy edge, we cannot reuse the group by clause
+                        _ => return Some(ReuseType::PrefixReuse),
+                    }
+                }
+                _ => continue
+            }
+        }
+
+        // Check that the new query's predicates imply the existing query's predicate.
+        for (name, ex_qgn) in &existing_qg.relations {
+            let new_qgn = &new_qg.relations[name];
+
+            // iterate over predicates and ensure that each matching one on the existing QG is implied
+            // by the new one
+            for ep in &ex_qgn.predicates {
+                let mut matched = false;
+
+                for np in &new_qgn.predicates {
+                    if complex_predicate_implies(np, ep) {
+                        matched = true;
+                        break
+                    }
+                }
+                if !matched {
+                    // We found no matching predicate for np, so we give up now.
+                    // However, we can still reuse the join nodes from the existing query.
+                    return Some(ReuseType::PrefixReuse);
+                }
+            }
+        }
+
+        // we don't need to check projected columns to reuse a prefix of the query
+        return Some(ReuseType::DirectExtension);
+    }
+}


### PR DESCRIPTION
Adds two reuse options other than the `Finkelstein` algorithm: `Relaxed` and `Full`. Also considers multiple reuse candidates, instead of using a scoring function to pick a single one.

- `Relaxed`: This algorithm relaxes some of the constraints in the `Finkelstein` algorithm. More specifically, it doesn't give up if a query graph is not a direct extension of an existing query graph. Instead, it tries to reuse prefixes of each query. 

- `Full`: This algorithm simply considers all query graphs as possible reuse candidates and tries to individually merge each of them into the new query being added. This should yield maximum possible reuse.

- Reuse numbers after migrating `hotsoup` until schema 66. This doesn't count reuse of base tables, queries that are an exact match, or queries that simply added a new reader node.

Reuse Alg  | # Nodes Reused | 
--- | --- |
`Finkelstein` | 34 |
`Relaxed` | 38 |
`Full` | 41 |