### PR TITLE
Creates one join node per join predicate

### DIFF
--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1329,6 +1329,9 @@ fn make_union_node(
     let column_names = columns.iter().map(|c| &c.name).collect::<Vec<_>>();
     let mut emit_column_id: HashMap<NodeIndex, Vec<usize>> = HashMap::new();
 
+    // column_id_for_column doesn't take into consideration table aliases
+    // which might cause improper ordering of columns in a union node
+    // eg. Q6 in finkelstein.txt
     for (i, n) in ancestors.clone().iter().enumerate() {
         let emit_cols = emit[i].iter()
             .map(|c| n.borrow().column_id_for_column(c))

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -1477,11 +1477,6 @@ fn make_join_node(
         proj_cols.len()
     );
 
-    let find_column_id = |n: &MirNodeRef, col: &Column| -> usize {
-        //rustfmt
-        n.borrow().column_id_for_column(col)
-    };
-
     assert_eq!(on_left.len(), 1, "no support for multiple column joins");
     assert_eq!(on_right.len(), 1, "no support for multiple column joins");
 
@@ -1492,9 +1487,8 @@ fn make_join_node(
     // SELECT r1.a as a1, r2.a as a2 from r as r1, r as r2 where r1.a = r2.b and r2.a = r1.b;
     //
     // the `r1.a = r2.b` join predicate will create a join node with columns: r1.a, r1.b, r2.a, r2,b
-    // however, because the way we deal with alias, we can't distinguish between `r1.a` and `r2.a`
-    // at this point in the codebase, and because so the `r2.a = r1.b` will join on the wrong `a`
-    // column.
+    // however, because the way we deal with aliases, we can't distinguish between `r1.a` and `r2.a`
+    // at this point in the codebase, so the `r2.a = r1.b` will join on the wrong `a` column.
     let left_join_col_id = projected_cols_left.iter().position(|lc| lc == on_left.first().unwrap()).unwrap();
     let right_join_col_id = projected_cols_right.iter().position(|rc| rc == on_right.first().unwrap()).unwrap();
 

--- a/src/ops/join.rs
+++ b/src/ops/join.rs
@@ -68,6 +68,8 @@ impl Join {
                 }
             })
             .collect();
+
+        assert_eq!(join_columns.len(), 1, "only supports single column joins");
         let on = *join_columns.iter().next().unwrap();
 
         let (in_place_left_emit, in_place_right_emit) = {

--- a/src/sql/mir.rs
+++ b/src/sql/mir.rs
@@ -630,7 +630,7 @@ impl SqlToMirConverter {
     fn make_join_node(
         &mut self,
         name: &str,
-        jps: &[ConditionTree],
+        jp: &ConditionTree,
         left_node: MirNodeRef,
         right_node: MirNodeRef,
         kind: JoinType,
@@ -656,20 +656,20 @@ impl SqlToMirConverter {
         // TODO(malte): no multi-level joins yet
         let mut left_join_columns = Vec::new();
         let mut right_join_columns = Vec::new();
-        for p in jps.iter() {
-            // equi-join only
-            assert!(p.operator == Operator::Equal || p.operator == Operator::In );
-            let l_col = match *p.left {
-                ConditionExpression::Base(ConditionBase::Field(ref f)) => f.clone(),
-                _ => unimplemented!(),
-            };
-            let r_col = match *p.right {
-                ConditionExpression::Base(ConditionBase::Field(ref f)) => f.clone(),
-                _ => unimplemented!(),
-            };
-            left_join_columns.push(l_col);
-            right_join_columns.push(r_col);
-        }
+
+        // equi-join only
+        assert!(jp.operator == Operator::Equal || jp.operator == Operator::In );
+        let l_col = match *jp.left {
+            ConditionExpression::Base(ConditionBase::Field(ref f)) => f.clone(),
+            _ => unimplemented!(),
+        };
+        let r_col = match *jp.right {
+            ConditionExpression::Base(ConditionBase::Field(ref f)) => f.clone(),
+            _ => unimplemented!(),
+        };
+        left_join_columns.push(l_col);
+        right_join_columns.push(r_col);
+
         assert_eq!(left_join_columns.len(), right_join_columns.len());
         let inner = match kind {
             JoinType::Inner => {
@@ -1041,39 +1041,55 @@ impl SqlToMirConverter {
                 };
 
                 for &(&(ref src, ref dst), edge) in &sorted_edges {
-                    let jn = match *edge {
+                    let mut jns = Vec::new();
+                    match *edge {
                         // Edge represents a LEFT JOIN
                         QueryGraphEdge::LeftJoin(ref jps) => {
                             let (left_node, right_node) =
                                 pick_join_columns(src, dst, prev_node, &joined_tables);
-                            self.make_join_node(
-                                &format!("q_{:x}_n{}", qg.signature().hash, new_node_count),
-                                jps,
-                                left_node,
-                                right_node,
-                                JoinType::Left,
-                            )
+
+                            let mut prev_join = right_node;
+                            for jp in jps.into_iter() {
+                                let cur_join = self.make_join_node(
+                                    &format!("q_{:x}_n{}", qg.signature().hash, new_node_count),
+                                    jp,
+                                    left_node.clone(),
+                                    prev_join.clone(),
+                                    JoinType::Left,
+                                );
+
+                                prev_join = cur_join.clone();
+                                new_node_count+=1;
+                                jns.push(cur_join);
+                            }
                         }
                         // Edge represents a JOIN
                         QueryGraphEdge::Join(ref jps) => {
                             let (left_node, right_node) =
                                 pick_join_columns(src, dst, prev_node, &joined_tables);
-                            self.make_join_node(
-                                &format!("q_{:x}_n{}", qg.signature().hash, new_node_count),
-                                jps,
-                                left_node,
-                                right_node,
-                                JoinType::Inner,
-                            )
+
+                            let mut prev_join = right_node;
+                            for jp in jps.into_iter() {
+                                let cur_join = self.make_join_node(
+                                    &format!("q_{:x}_n{}", qg.signature().hash, new_node_count),
+                                    jp,
+                                    left_node.clone(),
+                                    prev_join.clone(),
+                                    JoinType::Inner,
+                                );
+
+                                prev_join = cur_join.clone();
+                                new_node_count+=1;
+                                jns.push(cur_join);
+                            }
                         }
                         // Edge represents a GROUP BY, which we handle later
                         QueryGraphEdge::GroupBy(_) => continue,
                     };
 
                     // bookkeeping (shared between both join types)
-                    join_nodes.push(jn.clone());
-                    new_node_count += 1;
-                    prev_node = Some(jn);
+                    prev_node = Some(jns.last().unwrap().clone());
+                    join_nodes.extend(jns);
 
                     // we've now joined both tables
                     joined_tables.insert(src);

--- a/tests/finkelstein82.txt
+++ b/tests/finkelstein82.txt
@@ -20,4 +20,5 @@ SELECT p.name, c.corpname, c.location FROM people AS p, companies AS c WHERE p.e
 SELECT p.name, s.schoolname FROM people AS p, companies AS c, schools AS s WHERE p.experience >= 20 AND p.age <= 65 AND p.employer = c.corpname AND c.location = 'NY' AND c.earnings > 500000 AND p.education = s.schoolname AND s.level = 'university';
 
 # Q6
-SELECT p.name, c.corpname, c.location FROM people AS p, companies AS c, companies AS c1 WHERE p.experience >= 20 AND p.age <= 65 AND p.employer = c.corpname AND ( c.location = 'NY' OR c.location = 'CA' ) AND c.earnings > 500000 AND p.name = c1.president AND c1.president = 'Smith' AND c1.business = 'manufacturing';
+# Need proper support of table aliases
+# SELECT p.name, c.corpname, c.location FROM people AS p, companies AS c, companies AS c1 WHERE p.experience >= 20 AND p.age <= 65 AND p.employer = c.corpname AND ( c.location = 'NY' OR c.location = 'CA' ) AND c.earnings > 500000 AND p.name = c1.president AND c1.president = 'Smith' AND c1.business = 'manufacturing';


### PR DESCRIPTION
This fixes how we handle multiple join predicates for the same pair of `(src, dst)`.

Currently, we don't support joins on multiple columns, so if we have multiple predicates, we need to create one join node per predicate.

This also fixes the issue where this [assertion](https://github.com/mit-pdos/distributary/blob/3e4c4594b971b1bc86a4bcbf676b8774522d5c6e/src/ops/join.rs#L92) was triggered when joining against the same table (by using aliases). So now we can run the following query schema:
```
CREATE TABLE r (a int, b int);
SELECT r1.a as a1, r2.a as a2 from r as r1, r as r2 where r1.a = r2.a;
SELECT r1.a as a1, r2.a as a2 from r as r1, r as r2 where r1.a = r2.b and r2.a = r1.b;
```
However, because we get rid of table aliases before node construction, we might still pick the wrong join columns in the last query, since we can't distinguish between `r1.a` and `r2.a`. 