### PR TITLE
Web fixes

### DIFF
--- a/exercise-web.sh
+++ b/exercise-web.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 echo "Build"
-cargo build --bin web --features=web
+cargo build --bin web --features=binaries,web
 res=$?
 if [ "$res" -ne 0 ]; then
 	exit "$res"
 fi
 
 echo "Start"
-cargo run --bin web --features=web >/dev/null &
+cargo run --bin web --features=binaries,web >/dev/null &
 sleep 1
 pid=$(pgrep -f target/debug/web)
 

--- a/src/web/main.rs
+++ b/src/web/main.rs
@@ -55,7 +55,6 @@ fn main() {
     }
 
     web::run(Arc::new(Mutex::new(g))).unwrap();
-    loop {}
 }
 
 #[cfg(not(feature = "web"))]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -116,6 +116,10 @@ pub fn run(soup: Arc<Mutex<Blender>>) -> HttpResult<Listening> {
 
     insert_routes! {
         &mut router => {
+            "/" => Get: Box::new(move |_ctx: Context, mut res: Response| {
+                res.headers_mut().set(ContentType::html());
+                res.send(include_str!("graph.html"));
+            }) as Box<Handler>,
             "graph" => Get: Box::new(move |ctx: Context, mut res: Response| {
                 let m: &Arc<Mutex<Blender>> = ctx.global.get().unwrap();
                 res.headers_mut().set(ContentType::plaintext());
@@ -144,10 +148,17 @@ pub fn run(soup: Arc<Mutex<Blender>>) -> HttpResult<Listening> {
         }
     };
 
-    Server {
+    let port = 8080;
+    let result = Server {
         handlers: router,
-        host: 8080.into(),
+        host: port.into(),
         global: Global::from(Box::new(soup)),
         ..Server::default()
-    }.run()
+    }.run();
+
+    if let Ok(..) = result {
+        println!("Listening to port {}", port);
+    }
+
+    result
 }


### PR DESCRIPTION
A few minor changes related to the web targets:
* Adds `--features=binaries` to the cargo commands in `exercise-web.sh` so that it successfully compiles
* Uses `Recipe::from_str` for the queries in `sql_main.rs`. Previously panicked with a `entered unreachable code: asked for unset index for internal B node', src/flow/node/mod.rs:272:16` which I don't really know what means, but reading in the queries like this seems to have fixed it ¯\\\_(ツ)_/¯
* Prints out the running port number and serves `graph.html` at `/` as well (mostly since I couldn't figure out how it worked initially, and I think this would've made it easier to grok)

Neat graph!