### PR TITLE
Bump the settle time to get tests to pass on Travis

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 
 use std::collections::HashMap;
 
-const SETTLE_TIME_MS: u64 = 100;
+const SETTLE_TIME_MS: u64 = 500;
 
 #[test]
 fn it_works_basic() {


### PR DESCRIPTION
Looks like Travis is too slow for the tests in `lib/tests.rs`. Bumping the settle time to 500 ms seems to work (re-ran the tests a few times).