### PR TITLE
Make migrations happen in a closure

### DIFF
--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -24,22 +24,17 @@ fn load_recipe() -> Result<Backend, String> {
     let mut soup = Blender::new();
     soup.log_with(distributary::logger_pls());
 
-    let recipe;
-    {
-        let mut mig = soup.start_migration();
-
+    let recipe = soup.migrate(|mig| {
         // install recipe
-        recipe = match Recipe::from_str(&sql, None) {
+        match Recipe::from_str(&sql, None) {
             Ok(mut recipe) => {
-                recipe.activate(&mut mig, false)?;
+                recipe.activate(mig, false)?;
                 recipe
             }
             Err(e) => return Err(e),
-        };
-
-        // brings up new graph for processing
-        mig.commit();
-    }
+        }
+        // return brings up new graph for processing
+    });
 
     Ok(Backend::new(soup, recipe))
 }

--- a/src/flow/mod.rs
+++ b/src/flow/mod.rs
@@ -189,6 +189,7 @@ impl Blender {
     }
 
     /// Start setting up a new `Migration`.
+    #[deprecated]
     pub fn start_migration(&mut self) -> Migration {
         info!(self.log, "starting migration");
         let miglog = self.log.new(o!());
@@ -201,6 +202,27 @@ impl Blender {
             start: time::Instant::now(),
             log: miglog,
         }
+    }
+
+    /// Perform a new query schema migration.
+    pub fn migrate<F, T>(&mut self, f: F) -> T
+    where
+        F: FnOnce(&mut Migration) -> T,
+    {
+        info!(self.log, "starting migration");
+        let miglog = self.log.new(o!());
+        let mut m = Migration {
+            mainline: self,
+            added: Default::default(),
+            columns: Default::default(),
+            readers: Default::default(),
+
+            start: time::Instant::now(),
+            log: miglog,
+        };
+        let r = f(&mut m);
+        m.commit();
+        r
     }
 
     /// Get a boxed function which can be used to validate tokens.
@@ -979,10 +1001,8 @@ mod tests {
         let mut r = Recipe::from_str(r_txt, None).unwrap();
 
         let mut b = Blender::new();
-        {
-            let mut mig = b.start_migration();
-            assert!(r.activate(&mut mig, false).is_ok());
-            mig.commit();
-        }
+        b.migrate(|mig| {
+            assert!(r.activate(mig, false).is_ok());
+        });
     }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -684,37 +684,37 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Must have a base node for type inference to work, so make one manually
+            assert!(
+                "CREATE TABLE users (id int, name varchar(40));"
+                    .to_flow_parts(&mut inc, None, mig)
+                    .is_ok()
+            );
 
-        // Must have a base node for type inference to work, so make one manually
-        assert!(
-            "CREATE TABLE users (id int, name varchar(40));"
-                .to_flow_parts(&mut inc, None, &mut mig)
-                .is_ok()
-        );
+            // Should have two nodes: source and "users" base table
+            let ncount = mig.graph().node_count();
+            assert_eq!(ncount, 2);
+            assert_eq!(get_node(&inc, &*mig, "users").name(), "users");
 
-        // Should have two nodes: source and "users" base table
-        let ncount = mig.graph().node_count();
-        assert_eq!(ncount, 2);
-        assert_eq!(get_node(&inc, &mig, "users").name(), "users");
+            assert!(
+                "SELECT users.id from users;"
+                    .to_flow_parts(&mut inc, None, mig)
+                    .is_ok()
+            );
+            // Should now have source, "users", a leaf projection node for the new selection, and
+            // a reader node
+            assert_eq!(mig.graph().node_count(), ncount + 2);
 
-        assert!(
-            "SELECT users.id from users;"
-                .to_flow_parts(&mut inc, None, &mut mig)
-                .is_ok()
-        );
-        // Should now have source, "users", a leaf projection node for the new selection, and
-        // a reader node
-        assert_eq!(mig.graph().node_count(), ncount + 2);
-
-        // Invalid query should fail parsing and add no nodes
-        assert!(
-            "foo bar from whatever;"
-                .to_flow_parts(&mut inc, None, &mut mig)
-                .is_err()
-        );
-        // Should still only have source, "users" and the two nodes for the above selection
-        assert_eq!(mig.graph().node_count(), ncount + 2);
+            // Invalid query should fail parsing and add no nodes
+            assert!(
+                "foo bar from whatever;"
+                    .to_flow_parts(&mut inc, None, mig)
+                    .is_err()
+            );
+            // Should still only have source, "users" and the two nodes for the above selection
+            assert_eq!(mig.graph().node_count(), ncount + 2);
+        });
     }
 
     #[test]
@@ -722,60 +722,57 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish a base write type for "users"
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "users").name(), "users");
+            assert_eq!(get_node(&inc, &*mig, "users").fields(), &["id", "name"]);
+            assert_eq!(get_node(&inc, &*mig, "users").description(), "B");
 
-        // Establish a base write type for "users"
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "users").name(), "users");
-        assert_eq!(get_node(&inc, &mig, "users").fields(), &["id", "name"]);
-        assert_eq!(get_node(&inc, &mig, "users").description(), "B");
+            // Establish a base write type for "articles"
+            assert!(
+                inc.add_query(
+                    "CREATE TABLE articles (id int, author int, title varchar(255));",
+                    None,
+                    mig
+                ).is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 3);
+            assert_eq!(get_node(&inc, &*mig, "articles").name(), "articles");
+            assert_eq!(
+                get_node(&inc, &*mig, "articles").fields(),
+                &["id", "author", "title"]
+            );
+            assert_eq!(get_node(&inc, &*mig, "articles").description(), "B");
 
-        // Establish a base write type for "articles"
-        assert!(
-            inc.add_query(
-                "CREATE TABLE articles (id int, author int, title varchar(255));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 3);
-        assert_eq!(get_node(&inc, &mig, "articles").name(), "articles");
-        assert_eq!(
-            get_node(&inc, &mig, "articles").fields(),
-            &["id", "author", "title"]
-        );
-        assert_eq!(get_node(&inc, &mig, "articles").description(), "B");
-
-        // Try a simple equi-JOIN query
-        let q = "SELECT users.name, articles.title \
-                 FROM articles, users \
-                 WHERE users.id = articles.author;";
-        let q = inc.add_query(q, None, &mut mig);
-        assert!(q.is_ok());
-        let qid = query_id_hash(
-            &["articles", "users"],
-            &[&Column::from("articles.author"), &Column::from("users.id")],
-            &[&Column::from("articles.title"), &Column::from("users.name")],
-        );
-        // join node
-        let new_join_view = get_node(&inc, &mig, &format!("q_{:x}_n0", qid));
-        assert_eq!(
-            new_join_view.fields(),
-            &["id", "author", "title", "id", "name"]
-        );
-        // leaf node
-        let new_leaf_view = get_node(&inc, &mig, &q.unwrap().name);
-        assert_eq!(new_leaf_view.fields(), &["name", "title"]);
-        assert_eq!(new_leaf_view.description(), format!("π[4, 2]"));
+            // Try a simple equi-JOIN query
+            let q = "SELECT users.name, articles.title \
+                     FROM articles, users \
+                     WHERE users.id = articles.author;";
+            let q = inc.add_query(q, None, mig);
+            assert!(q.is_ok());
+            let qid = query_id_hash(
+                &["articles", "users"],
+                &[&Column::from("articles.author"), &Column::from("users.id")],
+                &[&Column::from("articles.title"), &Column::from("users.name")],
+            );
+            // join node
+            let new_join_view = get_node(&inc, &*mig, &format!("q_{:x}_n0", qid));
+            assert_eq!(
+                new_join_view.fields(),
+                &["id", "author", "title", "id", "name"]
+            );
+            // leaf node
+            let new_leaf_view = get_node(&inc, &*mig, &q.unwrap().name);
+            assert_eq!(new_leaf_view.fields(), &["name", "title"]);
+            assert_eq!(new_leaf_view.description(), format!("π[4, 2]"));
+        });
     }
 
     #[test]
@@ -783,43 +780,40 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish a base write type
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "users").name(), "users");
+            assert_eq!(get_node(&inc, &*mig, "users").fields(), &["id", "name"]);
+            assert_eq!(get_node(&inc, &*mig, "users").description(), "B");
 
-        // Establish a base write type
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
+            // Try a simple query
+            let res = inc.add_query(
+                "SELECT users.name FROM users WHERE users.id = 42;",
                 None,
-                &mut mig
-            ).is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "users").name(), "users");
-        assert_eq!(get_node(&inc, &mig, "users").fields(), &["id", "name"]);
-        assert_eq!(get_node(&inc, &mig, "users").description(), "B");
+                mig,
+            );
+            assert!(res.is_ok());
 
-        // Try a simple query
-        let res = inc.add_query(
-            "SELECT users.name FROM users WHERE users.id = 42;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-
-        let qid = query_id_hash(
-            &["users"],
-            &[&Column::from("users.id")],
-            &[&Column::from("users.name")],
-        );
-        // filter node
-        let filter = get_node(&inc, &mig, &format!("q_{:x}_n0_p0_f0", qid));
-        assert_eq!(filter.fields(), &["id", "name"]);
-        assert_eq!(filter.description(), format!("σ[f0 = 42]"));
-        // leaf view node
-        let edge = get_node(&inc, &mig, &res.unwrap().name);
-        assert_eq!(edge.fields(), &["name"]);
-        assert_eq!(edge.description(), format!("π[1]"));
+            let qid = query_id_hash(
+                &["users"],
+                &[&Column::from("users.id")],
+                &[&Column::from("users.name")],
+            );
+            // filter node
+            let filter = get_node(&inc, &*mig, &format!("q_{:x}_n0_p0_f0", qid));
+            assert_eq!(filter.fields(), &["id", "name"]);
+            assert_eq!(filter.description(), format!("σ[f0 = 42]"));
+            // leaf view node
+            let edge = get_node(&inc, &*mig, &res.unwrap().name);
+            assert_eq!(edge.fields(), &["name"]);
+            assert_eq!(edge.description(), format!("π[1]"));
+        });
     }
 
     #[test]
@@ -827,54 +821,54 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish a base write types
+            assert!(
+                inc.add_query("CREATE TABLE votes (aid int, userid int);", None, mig)
+                    .is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "votes").name(), "votes");
+            assert_eq!(get_node(&inc, &*mig, "votes").fields(), &["aid", "userid"]);
+            assert_eq!(get_node(&inc, &*mig, "votes").description(), "B");
 
-        // Establish a base write types
-        assert!(
-            inc.add_query("CREATE TABLE votes (aid int, userid int);", None, &mut mig)
-                .is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "votes").name(), "votes");
-        assert_eq!(get_node(&inc, &mig, "votes").fields(), &["aid", "userid"]);
-        assert_eq!(get_node(&inc, &mig, "votes").description(), "B");
-
-        // Try a simple COUNT function
-        let res = inc.add_query(
-            "SELECT COUNT(votes.userid) AS votes \
-             FROM votes GROUP BY votes.aid;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        println!("{:?}", res);
-        // added the aggregation and the edge view, and a reader
-        assert_eq!(mig.graph().node_count(), 5);
-        // check aggregation view
-        let f = Box::new(FunctionExpression::Count(
-            Column::from("votes.userid"),
-            false,
-        ));
-        let qid = query_id_hash(
-            &["computed_columns", "votes"],
-            &[&Column::from("votes.aid")],
-            &[
-                &Column {
-                    name: String::from("votes"),
-                    alias: Some(String::from("votes")),
-                    table: None,
-                    function: Some(f),
-                },
-            ],
-        );
-        let agg_view = get_node(&inc, &mig, &format!("q_{:x}_n0", qid));
-        assert_eq!(agg_view.fields(), &["aid", "votes"]);
-        assert_eq!(agg_view.description(), format!("|*| γ[0]"));
-        // check edge view
-        let edge_view = get_node(&inc, &mig, &res.unwrap().name);
-        assert_eq!(edge_view.fields(), &["votes"]);
-        assert_eq!(edge_view.description(), format!("π[1]"));
+            // Try a simple COUNT function
+            let res = inc.add_query(
+                "SELECT COUNT(votes.userid) AS votes \
+                 FROM votes GROUP BY votes.aid;",
+                None,
+                mig,
+            );
+            assert!(res.is_ok());
+            println!("{:?}", res);
+            // added the aggregation and the edge view, and a reader
+            assert_eq!(mig.graph().node_count(), 5);
+            // check aggregation view
+            let f = Box::new(FunctionExpression::Count(
+                Column::from("votes.userid"),
+                false,
+            ));
+            let qid = query_id_hash(
+                &["computed_columns", "votes"],
+                &[&Column::from("votes.aid")],
+                &[
+                    &Column {
+                        name: String::from("votes"),
+                        alias: Some(String::from("votes")),
+                        table: None,
+                        function: Some(f),
+                    },
+                ],
+            );
+            let agg_view = get_node(&inc, &*mig, &format!("q_{:x}_n0", qid));
+            assert_eq!(agg_view.fields(), &["aid", "votes"]);
+            assert_eq!(agg_view.description(), format!("|*| γ[0]"));
+            // check edge view
+            let edge_view = get_node(&inc, &*mig, &res.unwrap().name);
+            assert_eq!(edge_view.fields(), &["votes"]);
+            assert_eq!(edge_view.description(), format!("π[1]"));
+        });
     }
 
     #[test]
@@ -883,38 +877,27 @@ mod tests {
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
         inc.disable_reuse();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            let res = inc.add_query("SELECT id, name FROM users WHERE users.id = 42;", None, mig);
+            assert!(res.is_ok());
+            let leaf = res.unwrap().query_leaf;
 
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        let res = inc.add_query(
-            "SELECT id, name FROM users WHERE users.id = 42;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        let leaf = res.unwrap().query_leaf;
-
-        // Add the same query again; this should NOT reuse here.
-        let ncount = mig.graph().node_count();
-        let res = inc.add_query(
-            "SELECT name, id FROM users WHERE users.id = 42;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        // should have added nodes for this query, too
-        let qfp = res.unwrap();
-        assert_eq!(qfp.new_nodes.len(), 2);
-        // expect three new nodes: filter, project, reader
-        assert_eq!(mig.graph().node_count(), ncount + 3);
-        // should have ended up with a different leaf node
-        assert_ne!(qfp.query_leaf, leaf);
+            // Add the same query again; this should NOT reuse here.
+            let ncount = mig.graph().node_count();
+            let res = inc.add_query("SELECT name, id FROM users WHERE users.id = 42;", None, mig);
+            assert!(res.is_ok());
+            // should have added nodes for this query, too
+            let qfp = res.unwrap();
+            assert_eq!(qfp.new_nodes.len(), 2);
+            // expect three new nodes: filter, project, reader
+            assert_eq!(mig.graph().node_count(), ncount + 3);
+            // should have ended up with a different leaf node
+            assert_ne!(qfp.query_leaf, leaf);
+        });
     }
 
     #[test]
@@ -922,45 +905,34 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish a base write type
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "users").name(), "users");
+            assert_eq!(get_node(&inc, &*mig, "users").fields(), &["id", "name"]);
+            assert_eq!(get_node(&inc, &*mig, "users").description(), "B");
 
-        // Establish a base write type
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "users").name(), "users");
-        assert_eq!(get_node(&inc, &mig, "users").fields(), &["id", "name"]);
-        assert_eq!(get_node(&inc, &mig, "users").description(), "B");
+            // Add a new query
+            let res = inc.add_query("SELECT id, name FROM users WHERE users.id = 42;", None, mig);
+            assert!(res.is_ok());
+            let leaf = res.unwrap().query_leaf;
 
-        // Add a new query
-        let res = inc.add_query(
-            "SELECT id, name FROM users WHERE users.id = 42;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        let leaf = res.unwrap().query_leaf;
-
-        // Add the same query again
-        let ncount = mig.graph().node_count();
-        let res = inc.add_query(
-            "SELECT name, id FROM users WHERE users.id = 42;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        // should have added no more nodes
-        let qfp = res.unwrap();
-        assert_eq!(qfp.new_nodes, vec![]);
-        assert_eq!(mig.graph().node_count(), ncount);
-        // should have ended up with the same leaf node
-        assert_eq!(qfp.query_leaf, leaf);
+            // Add the same query again
+            let ncount = mig.graph().node_count();
+            let res = inc.add_query("SELECT name, id FROM users WHERE users.id = 42;", None, mig);
+            assert!(res.is_ok());
+            // should have added no more nodes
+            let qfp = res.unwrap();
+            assert_eq!(qfp.new_nodes, vec![]);
+            assert_eq!(mig.graph().node_count(), ncount);
+            // should have ended up with the same leaf node
+            assert_eq!(qfp.query_leaf, leaf);
+        });
     }
 
     #[test]
@@ -968,73 +940,70 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish a base write type
+            assert!(
+                inc.add_query(
+                    "CREATE TABLE users (id int, name varchar(40), address varchar(40));",
+                    None,
+                    mig
+                ).is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "users").name(), "users");
+            assert_eq!(
+                get_node(&inc, &*mig, "users").fields(),
+                &["id", "name", "address"]
+            );
+            assert_eq!(get_node(&inc, &*mig, "users").description(), "B");
 
-        // Establish a base write type
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40), address varchar(40));",
+            // Add a new query
+            let res = inc.add_query("SELECT id, name FROM users WHERE users.id = ?;", None, mig);
+            assert!(res.is_ok());
+
+            // Add the same query again, but with a parameter on a different column.
+            // Project the same columns, so we can reuse the projection that already exists and only
+            // add an identity node.
+            let ncount = mig.graph().node_count();
+            let res = inc.add_query(
+                "SELECT id, name FROM users WHERE users.name = ?;",
                 None,
-                &mut mig
-            ).is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "users").name(), "users");
-        assert_eq!(
-            get_node(&inc, &mig, "users").fields(),
-            &["id", "name", "address"]
-        );
-        assert_eq!(get_node(&inc, &mig, "users").description(), "B");
+                mig,
+            );
+            assert!(res.is_ok());
+            // should have added two more nodes: one identity node and one reader node
+            let qfp = res.unwrap();
+            assert_eq!(mig.graph().node_count(), ncount + 2);
+            // only the identity node is returned in the vector of new nodes
+            assert_eq!(qfp.new_nodes.len(), 1);
+            assert_eq!(get_node(&inc, &*mig, &qfp.name).description(), "≡");
+            // we should be based off the identity as our leaf
+            let id_node = qfp.new_nodes.iter().next().unwrap();
+            assert_eq!(qfp.query_leaf, *id_node);
 
-        // Add a new query
-        let res = inc.add_query(
-            "SELECT id, name FROM users WHERE users.id = ?;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-
-        // Add the same query again, but with a parameter on a different column.
-        // Project the same columns, so we can reuse the projection that already exists and only
-        // add an identity node.
-        let ncount = mig.graph().node_count();
-        let res = inc.add_query(
-            "SELECT id, name FROM users WHERE users.name = ?;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        // should have added two more nodes: one identity node and one reader node
-        let qfp = res.unwrap();
-        assert_eq!(mig.graph().node_count(), ncount + 2);
-        // only the identity node is returned in the vector of new nodes
-        assert_eq!(qfp.new_nodes.len(), 1);
-        assert_eq!(get_node(&inc, &mig, &qfp.name).description(), "≡");
-        // we should be based off the identity as our leaf
-        let id_node = qfp.new_nodes.iter().next().unwrap();
-        assert_eq!(qfp.query_leaf, *id_node);
-
-        // Do it again with a parameter on yet a different column.
-        // Project different columns, so we need to add a new projection (not an identity).
-        let ncount = mig.graph().node_count();
-        let res = inc.add_query(
-            "SELECT id, name FROM users WHERE users.address = ?;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        // should have added two more nodes: one projection node and one reader node
-        let qfp = res.unwrap();
-        assert_eq!(mig.graph().node_count(), ncount + 2);
-        // only the projection node is returned in the vector of new nodes
-        assert_eq!(qfp.new_nodes.len(), 1);
-        assert_eq!(get_node(&inc, &mig, &qfp.name).description(), "π[0, 1, 2]");
-        // we should be based off the new projection as our leaf
-        let id_node = qfp.new_nodes.iter().next().unwrap();
-        assert_eq!(qfp.query_leaf, *id_node);
-
-        mig.commit();
+            // Do it again with a parameter on yet a different column.
+            // Project different columns, so we need to add a new projection (not an identity).
+            let ncount = mig.graph().node_count();
+            let res = inc.add_query(
+                "SELECT id, name FROM users WHERE users.address = ?;",
+                None,
+                mig,
+            );
+            assert!(res.is_ok());
+            // should have added two more nodes: one projection node and one reader node
+            let qfp = res.unwrap();
+            assert_eq!(mig.graph().node_count(), ncount + 2);
+            // only the projection node is returned in the vector of new nodes
+            assert_eq!(qfp.new_nodes.len(), 1);
+            assert_eq!(
+                get_node(&inc, &*mig, &qfp.name).description(),
+                "π[0, 1, 2]"
+            );
+            // we should be based off the new projection as our leaf
+            let id_node = qfp.new_nodes.iter().next().unwrap();
+            assert_eq!(qfp.query_leaf, *id_node);
+        });
     }
 
     #[test]
@@ -1042,56 +1011,52 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
-
-        // Establish a base write type
-        assert!(
-            inc.add_query("CREATE TABLE votes (aid int, userid int);", None, &mut mig)
-                .is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "votes").name(), "votes");
-        assert_eq!(get_node(&inc, &mig, "votes").fields(), &["aid", "userid"]);
-        assert_eq!(get_node(&inc, &mig, "votes").description(), "B");
-        // Try a simple COUNT function without a GROUP BY clause
-        let res = inc.add_query(
-            "SELECT COUNT(votes.userid) AS count FROM votes;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        // added the aggregation, a project helper, the edge view, and reader
-        assert_eq!(mig.graph().node_count(), 6);
-        // check project helper node
-        let f = Box::new(FunctionExpression::Count(
-            Column::from("votes.userid"),
-            false,
-        ));
-        let qid = query_id_hash(
-            &["computed_columns", "votes"],
-            &[],
-            &[
-                &Column {
-                    name: String::from("count"),
-                    alias: Some(String::from("count")),
-                    table: None,
-                    function: Some(f),
-                },
-            ],
-        );
-        let proj_helper_view = get_node(&inc, &mig, &format!("q_{:x}_n0_prj_hlpr", qid));
-        assert_eq!(proj_helper_view.fields(), &["userid", "grp"]);
-        assert_eq!(proj_helper_view.description(), format!("π[1, lit: 0]"));
-        // check aggregation view
-        let agg_view = get_node(&inc, &mig, &format!("q_{:x}_n0", qid));
-        assert_eq!(agg_view.fields(), &["grp", "count"]);
-        assert_eq!(agg_view.description(), format!("|*| γ[1]"));
-        // check edge view -- note that it's not actually currently possible to read from
-        // this for a lack of key (the value would be the key)
-        let edge_view = get_node(&inc, &mig, &res.unwrap().name);
-        assert_eq!(edge_view.fields(), &["count"]);
-        assert_eq!(edge_view.description(), format!("π[1]"));
+        g.migrate(|mig| {
+            // Establish a base write type
+            assert!(
+                inc.add_query("CREATE TABLE votes (aid int, userid int);", None, mig)
+                    .is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "votes").name(), "votes");
+            assert_eq!(get_node(&inc, &*mig, "votes").fields(), &["aid", "userid"]);
+            assert_eq!(get_node(&inc, &*mig, "votes").description(), "B");
+            // Try a simple COUNT function without a GROUP BY clause
+            let res = inc.add_query("SELECT COUNT(votes.userid) AS count FROM votes;", None, mig);
+            assert!(res.is_ok());
+            // added the aggregation, a project helper, the edge view, and reader
+            assert_eq!(mig.graph().node_count(), 6);
+            // check project helper node
+            let f = Box::new(FunctionExpression::Count(
+                Column::from("votes.userid"),
+                false,
+            ));
+            let qid = query_id_hash(
+                &["computed_columns", "votes"],
+                &[],
+                &[
+                    &Column {
+                        name: String::from("count"),
+                        alias: Some(String::from("count")),
+                        table: None,
+                        function: Some(f),
+                    },
+                ],
+            );
+            let proj_helper_view = get_node(&inc, &*mig, &format!("q_{:x}_n0_prj_hlpr", qid));
+            assert_eq!(proj_helper_view.fields(), &["userid", "grp"]);
+            assert_eq!(proj_helper_view.description(), format!("π[1, lit: 0]"));
+            // check aggregation view
+            let agg_view = get_node(&inc, &*mig, &format!("q_{:x}_n0", qid));
+            assert_eq!(agg_view.fields(), &["grp", "count"]);
+            assert_eq!(agg_view.description(), format!("|*| γ[1]"));
+            // check edge view -- note that it's not actually currently possible to read from
+            // this for a lack of key (the value would be the key)
+            let edge_view = get_node(&inc, &*mig, &res.unwrap().name);
+            assert_eq!(edge_view.fields(), &["count"]);
+            assert_eq!(edge_view.description(), format!("π[1]"));
+        });
     }
 
     #[test]
@@ -1099,49 +1064,49 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
-
-        // Establish a base write type
-        assert!(
-            inc.add_query("CREATE TABLE votes (userid int, aid int);", None, &mut mig)
-                .is_ok()
-        );
-        // Should have source and "users" base table node
-        assert_eq!(mig.graph().node_count(), 2);
-        assert_eq!(get_node(&inc, &mig, "votes").name(), "votes");
-        assert_eq!(get_node(&inc, &mig, "votes").fields(), &["userid", "aid"]);
-        assert_eq!(get_node(&inc, &mig, "votes").description(), "B");
-        // Try a simple COUNT function without a GROUP BY clause
-        let res = inc.add_query(
-            "SELECT COUNT(*) AS count FROM votes GROUP BY votes.userid;",
-            None,
-            &mut mig,
-        );
-        assert!(res.is_ok());
-        // added the aggregation, a project helper, the edge view, and reader
-        assert_eq!(mig.graph().node_count(), 5);
-        // check aggregation view
-        let f = Box::new(FunctionExpression::Count(Column::from("votes.aid"), false));
-        let qid = query_id_hash(
-            &["computed_columns", "votes"],
-            &[&Column::from("votes.userid")],
-            &[
-                &Column {
-                    name: String::from("count"),
-                    alias: Some(String::from("count")),
-                    table: None,
-                    function: Some(f),
-                },
-            ],
-        );
-        let agg_view = get_node(&inc, &mig, &format!("q_{:x}_n0", qid));
-        assert_eq!(agg_view.fields(), &["userid", "count"]);
-        assert_eq!(agg_view.description(), format!("|*| γ[0]"));
-        // check edge view -- note that it's not actually currently possible to read from
-        // this for a lack of key (the value would be the key)
-        let edge_view = get_node(&inc, &mig, &res.unwrap().name);
-        assert_eq!(edge_view.fields(), &["count"]);
-        assert_eq!(edge_view.description(), format!("π[1]"));
+        g.migrate(|mig| {
+            // Establish a base write type
+            assert!(
+                inc.add_query("CREATE TABLE votes (userid int, aid int);", None, mig)
+                    .is_ok()
+            );
+            // Should have source and "users" base table node
+            assert_eq!(mig.graph().node_count(), 2);
+            assert_eq!(get_node(&inc, &*mig, "votes").name(), "votes");
+            assert_eq!(get_node(&inc, &*mig, "votes").fields(), &["userid", "aid"]);
+            assert_eq!(get_node(&inc, &*mig, "votes").description(), "B");
+            // Try a simple COUNT function without a GROUP BY clause
+            let res = inc.add_query(
+                "SELECT COUNT(*) AS count FROM votes GROUP BY votes.userid;",
+                None,
+                mig,
+            );
+            assert!(res.is_ok());
+            // added the aggregation, a project helper, the edge view, and reader
+            assert_eq!(mig.graph().node_count(), 5);
+            // check aggregation view
+            let f = Box::new(FunctionExpression::Count(Column::from("votes.aid"), false));
+            let qid = query_id_hash(
+                &["computed_columns", "votes"],
+                &[&Column::from("votes.userid")],
+                &[
+                    &Column {
+                        name: String::from("count"),
+                        alias: Some(String::from("count")),
+                        table: None,
+                        function: Some(f),
+                    },
+                ],
+            );
+            let agg_view = get_node(&inc, &*mig, &format!("q_{:x}_n0", qid));
+            assert_eq!(agg_view.fields(), &["userid", "count"]);
+            assert_eq!(agg_view.description(), format!("|*| γ[0]"));
+            // check edge view -- note that it's not actually currently possible to read from
+            // this for a lack of key (the value would be the key)
+            let edge_view = get_node(&inc, &*mig, &res.unwrap().name);
+            assert_eq!(edge_view.fields(), &["count"]);
+            assert_eq!(edge_view.description(), format!("π[1]"));
+        });
     }
 
     #[test]
@@ -1149,54 +1114,51 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish base write types for "users" and "articles" and "votes"
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            assert!(
+                inc.add_query("CREATE TABLE votes (aid int, uid int);", None, mig)
+                    .is_ok()
+            );
+            assert!(
+                inc.add_query(
+                    "CREATE TABLE articles (aid int, title varchar(255), author int);",
+                    None,
+                    mig
+                ).is_ok()
+            );
 
-        // Establish base write types for "users" and "articles" and "votes"
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        assert!(
-            inc.add_query("CREATE TABLE votes (aid int, uid int);", None, &mut mig)
-                .is_ok()
-        );
-        assert!(
-            inc.add_query(
-                "CREATE TABLE articles (aid int, title varchar(255), author int);",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-
-        // Try an explicit multi-way-join
-        let q = "SELECT users.name, articles.title, votes.uid \
+            // Try an explicit multi-way-join
+            let q = "SELECT users.name, articles.title, votes.uid \
                  FROM articles
                  JOIN users ON (users.id = articles.author) \
                  JOIN votes ON (votes.aid = articles.aid);";
-        let q = inc.add_query(q, None, &mut mig);
-        assert!(q.is_ok());
-        let _qid = query_id_hash(
-            &["articles", "users", "votes"],
-            &[
-                &Column::from("articles.aid"),
-                &Column::from("articles.author"),
-                &Column::from("users.id"),
-                &Column::from("votes.aid"),
-            ],
-            &[
-                &Column::from("users.name"),
-                &Column::from("articles.title"),
-                &Column::from("votes.uid"),
-            ],
-        );
-        // XXX(malte): non-deterministic join ordering make it difficult to assert on the join
-        // views
-        // leaf view
-        let leaf_view = get_node(&inc, &mig, "q_3");
-        assert_eq!(leaf_view.fields(), &["name", "title", "uid"]);
+            let q = inc.add_query(q, None, mig);
+            assert!(q.is_ok());
+            let _qid = query_id_hash(
+                &["articles", "users", "votes"],
+                &[
+                    &Column::from("articles.aid"),
+                    &Column::from("articles.author"),
+                    &Column::from("users.id"),
+                    &Column::from("votes.aid"),
+                ],
+                &[
+                    &Column::from("users.name"),
+                    &Column::from("articles.title"),
+                    &Column::from("votes.uid"),
+                ],
+            );
+            // XXX(malte): non-deterministic join ordering make it difficult to assert on the join
+            // views
+            // leaf view
+            let leaf_view = get_node(&inc, &*mig, "q_3");
+            assert_eq!(leaf_view.fields(), &["name", "title", "uid"]);
+        });
     }
 
     #[test]
@@ -1204,66 +1166,63 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            // Establish base write types for "users" and "articles" and "votes"
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            assert!(
+                inc.add_query("CREATE TABLE votes (aid int, uid int);", None, mig)
+                    .is_ok()
+            );
+            assert!(
+                inc.add_query(
+                    "CREATE TABLE articles (aid int, title varchar(255), author int);",
+                    None,
+                    mig
+                ).is_ok()
+            );
 
-        // Establish base write types for "users" and "articles" and "votes"
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        assert!(
-            inc.add_query("CREATE TABLE votes (aid int, uid int);", None, &mut mig)
-                .is_ok()
-        );
-        assert!(
-            inc.add_query(
-                "CREATE TABLE articles (aid int, title varchar(255), author int);",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-
-        // Try an implicit multi-way-join
-        let q = "SELECT users.name, articles.title, votes.uid \
+            // Try an implicit multi-way-join
+            let q = "SELECT users.name, articles.title, votes.uid \
                  FROM articles, users, votes
                  WHERE users.id = articles.author \
                  AND votes.aid = articles.aid;";
-        let q = inc.add_query(q, None, &mut mig);
-        assert!(q.is_ok());
-        // XXX(malte): below over-projects into the final leaf, and is thus inconsistent
-        // with the explicit JOIN case!
-        let qid = query_id_hash(
-            &["articles", "users", "votes"],
-            &[
-                &Column::from("articles.aid"),
-                &Column::from("articles.author"),
-                &Column::from("users.id"),
-                &Column::from("votes.aid"),
-            ],
-            &[
-                &Column::from("articles.title"),
-                &Column::from("users.name"),
-                &Column::from("votes.uid"),
-            ],
-        );
-        let join1_view = get_node(&inc, &mig, &format!("q_{:x}_n0", qid));
-        // articles join votes
-        assert_eq!(
-            join1_view.fields(),
-            &["aid", "title", "author", "id", "name"]
-        );
-        let join2_view = get_node(&inc, &mig, &format!("q_{:x}_n1", qid));
-        // join1_view join users
-        assert_eq!(
-            join2_view.fields(),
-            &["aid", "title", "author", "id", "name", "aid", "uid"]
-        );
-        // leaf view
-        let leaf_view = get_node(&inc, &mig, "q_3");
-        assert_eq!(leaf_view.fields(), &["name", "title", "uid"]);
+            let q = inc.add_query(q, None, mig);
+            assert!(q.is_ok());
+            // XXX(malte): below over-projects into the final leaf, and is thus inconsistent
+            // with the explicit JOIN case!
+            let qid = query_id_hash(
+                &["articles", "users", "votes"],
+                &[
+                    &Column::from("articles.aid"),
+                    &Column::from("articles.author"),
+                    &Column::from("users.id"),
+                    &Column::from("votes.aid"),
+                ],
+                &[
+                    &Column::from("articles.title"),
+                    &Column::from("users.name"),
+                    &Column::from("votes.uid"),
+                ],
+            );
+            let join1_view = get_node(&inc, &*mig, &format!("q_{:x}_n0", qid));
+            // articles join votes
+            assert_eq!(
+                join1_view.fields(),
+                &["aid", "title", "author", "id", "name"]
+            );
+            let join2_view = get_node(&inc, &*mig, &format!("q_{:x}_n1", qid));
+            // join1_view join users
+            assert_eq!(
+                join2_view.fields(),
+                &["aid", "title", "author", "id", "name", "aid", "uid"]
+            );
+            // leaf view
+            let leaf_view = get_node(&inc, &*mig, "q_3");
+            assert_eq!(leaf_view.fields(), &["name", "title", "uid"]);
+        });
     }
 
     #[test]
@@ -1271,72 +1230,66 @@ mod tests {
         // set up graph
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
 
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
+            let res = inc.add_query("SELECT users.name, 1 FROM users;", None, mig);
+            assert!(res.is_ok());
 
-        let res = inc.add_query("SELECT users.name, 1 FROM users;", None, &mut mig);
-        assert!(res.is_ok());
-
-        // leaf view node
-        let edge = get_node(&inc, &mig, &res.unwrap().name);
-        assert_eq!(edge.fields(), &["name", "literal"]);
-        assert_eq!(edge.description(), format!("π[1, lit: 1]"));
+            // leaf view node
+            let edge = get_node(&inc, &*mig, &res.unwrap().name);
+            assert_eq!(edge.fields(), &["name", "literal"]);
+            assert_eq!(edge.description(), format!("π[1, lit: 1]"));
+        });
     }
 
     #[test]
     fn it_incorporates_join_with_nested_query() {
         let mut g = Blender::new();
         let mut inc = SqlIncorporator::default();
-        let mut mig = g.start_migration();
+        g.migrate(|mig| {
+            assert!(
+                inc.add_query("CREATE TABLE users (id int, name varchar(40));", None, mig)
+                    .is_ok()
+            );
+            assert!(
+                inc.add_query(
+                    "CREATE TABLE articles (id int, author int, title varchar(255));",
+                    None,
+                    mig
+                ).is_ok()
+            );
 
-        assert!(
-            inc.add_query(
-                "CREATE TABLE users (id int, name varchar(40));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-        assert!(
-            inc.add_query(
-                "CREATE TABLE articles (id int, author int, title varchar(255));",
-                None,
-                &mut mig
-            ).is_ok()
-        );
-
-        let q = "SELECT nested_users.name, articles.title \
-                 FROM articles \
-                 JOIN (SELECT * FROM users) AS nested_users \
-                 ON (nested_users.id = articles.author);";
-        let q = inc.add_query(q, None, &mut mig);
-        assert!(q.is_ok());
-        let qid = query_id_hash(
-            &["articles", "nested_users"],
-            &[
-                &Column::from("articles.author"),
-                &Column::from("nested_users.id"),
-            ],
-            &[
-                &Column::from("articles.title"),
-                &Column::from("nested_users.name"),
-            ],
-        );
-        // join node
-        let new_join_view = get_node(&inc, &mig, &format!("q_{:x}_n0", qid));
-        assert_eq!(
-            new_join_view.fields(),
-            &["id", "name", "id", "author", "title"]
-        );
-        // leaf node
-        let new_leaf_view = get_node(&inc, &mig, &q.unwrap().name);
-        assert_eq!(new_leaf_view.fields(), &["name", "title"]);
-        assert_eq!(new_leaf_view.description(), format!("π[1, 4]"));
+            let q = "SELECT nested_users.name, articles.title \
+                     FROM articles \
+                     JOIN (SELECT * FROM users) AS nested_users \
+                     ON (nested_users.id = articles.author);";
+            let q = inc.add_query(q, None, mig);
+            assert!(q.is_ok());
+            let qid = query_id_hash(
+                &["articles", "nested_users"],
+                &[
+                    &Column::from("articles.author"),
+                    &Column::from("nested_users.id"),
+                ],
+                &[
+                    &Column::from("articles.title"),
+                    &Column::from("nested_users.name"),
+                ],
+            );
+            // join node
+            let new_join_view = get_node(&inc, &*mig, &format!("q_{:x}_n0", qid));
+            assert_eq!(
+                new_join_view.fields(),
+                &["id", "name", "id", "author", "title"]
+            );
+            // leaf node
+            let new_leaf_view = get_node(&inc, &*mig, &q.unwrap().name);
+            assert_eq!(new_leaf_view.fields(), &["name", "title"]);
+            assert_eq!(new_leaf_view.description(), format!("π[1, 4]"));
+        });
     }
 }

--- a/src/web/sql_main.rs
+++ b/src/web/sql_main.rs
@@ -26,13 +26,11 @@ fn main() {
                FROM awvc GROUP BY awvc.user;
     ";
 
-    {
+    g.migrate(|mig| {
         // migrate from the empty recipe to below
-        let mut mig = g.start_migration();
         let mut recipe = Recipe::from_str(&sql, None).unwrap();
-        recipe.activate(&mut mig, false).unwrap();
-        mig.commit();
-    }
+        recipe.activate(mig, false).unwrap();
+    });
 
     println!("{}", g);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -18,8 +18,7 @@ fn it_works_basic() {
         time::Duration::from_millis(1),
     );
     g.with_persistence_options(pparams);
-    let (a, b, c) = {
-        let mut mig = g.start_migration();
+    let (a, b, c) = g.migrate(|mig| {
         let a = mig.add_ingredient(
             "a",
             &["a", "b"],
@@ -37,9 +36,8 @@ fn it_works_basic() {
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
         mig.maintain(c, 0);
-        mig.commit();
         (a, b, c)
-    };
+    });
 
     let cq = g.get_getter(c).unwrap();
     let mut muta = g.get_mutator(a);
@@ -89,8 +87,7 @@ fn it_works_basic() {
 fn it_works_streaming() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, b, cq) = {
-        let mut mig = g.start_migration();
+    let (a, b, cq) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
 
@@ -100,9 +97,8 @@ fn it_works_streaming() {
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
         let cq = mig.stream(c);
-        mig.commit();
         (a, b, cq)
-    };
+    });
 
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
@@ -127,8 +123,7 @@ fn it_works_streaming() {
 fn shared_interdomain_ancestor() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, bq, cq) = {
-        let mut mig = g.start_migration();
+    let (a, bq, cq) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
 
         let mut emits = HashMap::new();
@@ -141,10 +136,8 @@ fn shared_interdomain_ancestor() {
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
         let cq = mig.stream(c);
-
-        mig.commit();
         (a, bq, cq)
-    };
+    });
 
     let mut muta = g.get_mutator(a);
     let id: distributary::DataType = 1.into();
@@ -176,8 +169,7 @@ fn shared_interdomain_ancestor() {
 fn it_works_w_mat() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, b, c) = {
-        let mut mig = g.start_migration();
+    let (a, b, c) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
 
@@ -187,9 +179,8 @@ fn it_works_w_mat() {
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
         mig.maintain(c, 0);
-        mig.commit();
         (a, b, c)
-    };
+    });
 
     let cq = g.get_getter(c).unwrap();
     let mut muta = g.get_mutator(a);
@@ -235,8 +226,7 @@ fn it_works_w_mat() {
 fn it_works_deletion() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, b, cq) = {
-        let mut mig = g.start_migration();
+    let (a, b, cq) = g.migrate(|mig| {
         let a = mig.add_ingredient(
             "a",
             &["x", "y"],
@@ -254,9 +244,8 @@ fn it_works_deletion() {
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["x", "y"], u);
         let cq = mig.stream(c);
-        mig.commit();
         (a, b, cq)
-    };
+    });
 
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
@@ -292,13 +281,11 @@ fn it_works_with_sql_recipe() {
         CountCars: SELECT COUNT(*) FROM Car WHERE brand = ?;
     ";
 
-    let recipe = {
-        let mut mig = g.start_migration();
+    let recipe = g.migrate(|mig| {
         let mut recipe = distributary::Recipe::from_str(&sql, None).unwrap();
-        recipe.activate(&mut mig, false).unwrap();
-        mig.commit();
+        recipe.activate(mig, false).unwrap();
         recipe
-    };
+    });
 
     let car_index = recipe.node_addr_for("Car").unwrap();
     let count_index = recipe.node_addr_for("CountCars").unwrap();
@@ -325,9 +312,7 @@ fn votes() {
 
     // set up graph
     let mut g = distributary::Blender::new();
-    let (article1, article2, vote, article, vc, end) = {
-        let mut mig = g.start_migration();
-
+    let (article1, article2, vote, article, vc, end) = g.migrate(|mig| {
         // add article base nodes (we use two so we can exercise unions too)
         let article1 = mig.add_ingredient("article1", &["id", "title"], Base::default());
         let article2 = mig.add_ingredient("article1", &["id", "title"], Base::default());
@@ -357,10 +342,8 @@ fn votes() {
         let end = mig.add_ingredient("end", &["id", "title", "votes"], j);
         mig.maintain(end, 0);
 
-        // start processing
-        mig.commit();
         (article1, article2, vote, article, vc, end)
-    };
+    });
 
     let articleq = g.get_getter(article).unwrap();
     let vcq = g.get_getter(vc).unwrap();
@@ -438,9 +421,7 @@ fn transactional_vote() {
     g.disable_partial(); // because end_votes forces full below partial
     let validate = g.get_validator();
 
-    let (article1, article2, vote, article, vc, end, end_title, end_votes) = {
-        let mut mig = g.start_migration();
-
+    let (article1, article2, vote, article, vc, end, end_title, end_votes) = g.migrate(|mig| {
         // add article base nodes (we use two so we can exercise unions too)
         let article1 = mig.add_transactional_base("article1", &["id", "title"], Base::default());
         let article2 = mig.add_transactional_base("article1", &["id", "title"], Base::default());
@@ -475,8 +456,6 @@ fn transactional_vote() {
         mig.maintain(end_title, 1);
         mig.maintain(end_votes, 2);
 
-        // start processing
-        mig.commit();
         (
             article1,
             article2,
@@ -487,7 +466,7 @@ fn transactional_vote() {
             end_title,
             end_votes,
         )
-    };
+    });
 
     let mut articleq = g.get_getter(article).unwrap();
     let vcq = g.get_getter(vc).unwrap();
@@ -593,13 +572,9 @@ fn transactional_vote() {
 fn empty_migration() {
     // set up graph
     let mut g = distributary::Blender::new();
-    {
-        let mig = g.start_migration();
-        mig.commit();
-    }
+    g.migrate(|_| {});
 
-    let (a, b, c) = {
-        let mut mig = g.start_migration();
+    let (a, b, c) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
 
@@ -609,9 +584,8 @@ fn empty_migration() {
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
         mig.maintain(c, 0);
-        mig.commit();
         (a, b, c)
-    };
+    });
 
     let cq = g.get_getter(c).unwrap();
     let mut muta = g.get_mutator(a);
@@ -645,13 +619,11 @@ fn simple_migration() {
 
     // set up graph
     let mut g = distributary::Blender::new();
-    let a = {
-        let mut mig = g.start_migration();
+    let a = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         mig.maintain(a, 0);
-        mig.commit();
         a
-    };
+    });
 
     let aq = g.get_getter(a).unwrap();
     let mut muta = g.get_mutator(a);
@@ -666,13 +638,11 @@ fn simple_migration() {
     assert_eq!(aq.lookup(&id, true), Ok(vec![vec![1.into(), 2.into()]]));
 
     // add unrelated node b in a migration
-    let b = {
-        let mut mig = g.start_migration();
+    let b = g.migrate(|mig| {
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
         mig.maintain(b, 0);
-        mig.commit();
         b
-    };
+    });
 
     let bq = g.get_getter(b).unwrap();
     let mut mutb = g.get_mutator(b);
@@ -693,17 +663,15 @@ fn add_columns() {
 
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, aq) = {
-        let mut mig = g.start_migration();
+    let (a, aq) = g.migrate(|mig| {
         let a = mig.add_ingredient(
             "a",
             &["a", "b"],
             distributary::Base::new(vec![1.into(), 2.into()]),
         );
         let aq = mig.stream(a);
-        mig.commit();
         (a, aq)
-    };
+    });
     let mut muta = g.get_mutator(a);
 
     // send a value on a
@@ -716,11 +684,9 @@ fn add_columns() {
     );
 
     // add a third column to a
-    {
-        let mut mig = g.start_migration();
+    g.migrate(|mig| {
         mig.add_column(a, "c", 3.into());
-        mig.commit();
-    }
+    });
 
     // send another (old) value on a
     muta.put(vec![id.clone(), "z".into()]).unwrap();
@@ -748,16 +714,14 @@ fn migrate_added_columns() {
 
     // set up graph
     let mut g = distributary::Blender::new();
-    let a = {
-        let mut mig = g.start_migration();
+    let a = g.migrate(|mig| {
         let a = mig.add_ingredient(
             "a",
             &["a", "b"],
             distributary::Base::new(vec![1.into(), 2.into()]),
         );
-        mig.commit();
         a
-    };
+    });
     let mut muta = g.get_mutator(a);
 
     // send a value on a
@@ -765,8 +729,7 @@ fn migrate_added_columns() {
     thread::sleep(time::Duration::from_millis(SETTLE_TIME_MS));
 
     // add a third column to a, and a view that uses it
-    let b = {
-        let mut mig = g.start_migration();
+    let b = g.migrate(|mig| {
         mig.add_column(a, "c", 3.into());
         let b = mig.add_ingredient(
             "x",
@@ -774,9 +737,8 @@ fn migrate_added_columns() {
             distributary::Project::new(a, &[2, 0], None),
         );
         mig.maintain(b, 1);
-        mig.commit();
         b
-    };
+    });
 
     let bq = g.get_getter(b).unwrap();
 
@@ -808,17 +770,15 @@ fn migrate_drop_columns() {
 
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, stream) = {
-        let mut mig = g.start_migration();
+    let (a, stream) = g.migrate(|mig| {
         let a = mig.add_ingredient(
             "a",
             &["a", "b"],
             distributary::Base::new(vec!["a".into(), "b".into()]),
         );
         let stream = mig.stream(a);
-        mig.commit();
         (a, stream)
-    };
+    });
     let mut muta1 = g.get_mutator(a);
 
     // send a value on a
@@ -826,11 +786,9 @@ fn migrate_drop_columns() {
     thread::sleep(time::Duration::from_millis(SETTLE_TIME_MS));
 
     // drop a column
-    {
-        let mut mig = g.start_migration();
+    g.migrate(|mig| {
         mig.drop_column(a, 1);
-        mig.commit();
-    }
+    });
 
     // new mutator should only require one column
     // and should inject default for a.b
@@ -839,11 +797,9 @@ fn migrate_drop_columns() {
     thread::sleep(time::Duration::from_millis(SETTLE_TIME_MS));
 
     // add a new column
-    {
-        let mut mig = g.start_migration();
+    g.migrate(|mig| {
         mig.add_column(a, "c", "c".into());
-        mig.commit();
-    }
+    });
 
     // new mutator allows putting two values, and injects default for a.b
     let mut muta3 = g.get_mutator(a);
@@ -884,20 +840,17 @@ fn migrate_drop_columns() {
 fn key_on_added() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let a = {
-        let mut mig = g.start_migration();
+    let a = g.migrate(|mig| {
         let a = mig.add_ingredient(
             "a",
             &["a", "b"],
             distributary::Base::new(vec![1.into(), 2.into()]),
         );
-        mig.commit();
         a
-    };
+    });
 
     // add a maintained view keyed on newly added column
-    let b = {
-        let mut mig = g.start_migration();
+    let b = g.migrate(|mig| {
         mig.add_column(a, "c", 3.into());
         let b = mig.add_ingredient(
             "x",
@@ -905,9 +858,8 @@ fn key_on_added() {
             distributary::Project::new(a, &[2, 1], None),
         );
         mig.maintain(b, 0);
-        mig.commit();
         b
-    };
+    });
 
     // make sure we can read (may trigger a replay)
     let bq = g.get_getter(b).unwrap();
@@ -922,8 +874,7 @@ fn replay_during_replay() {
     // right in a left join, that's what we have to construct.
     let mut g = distributary::Blender::new();
     g.disable_sharding();
-    let (a, u1, u2) = {
-        let mut mig = g.start_migration();
+    let (a, u1, u2) = g.migrate(|mig| {
         // we need three bases:
         //
         //  - a will be the left side of the left join
@@ -936,13 +887,11 @@ fn replay_during_replay() {
             &["u", "a"],
             distributary::Base::new(vec![1.into(), 2.into()]),
         );
-        mig.commit();
         (a, u1, u2)
-    };
+    });
 
     // add our joins
-    let (u, target) = {
-        let mut mig = g.start_migration();
+    let (u, target) = g.migrate(|mig| {
         use distributary::{Join, JoinType};
         use distributary::JoinSource::*;
         // u = u1 * u2
@@ -951,9 +900,8 @@ fn replay_during_replay() {
         let j = Join::new(a, u, JoinType::Left, vec![B(0, 1), R(0)]);
         let end = mig.add_ingredient("end", &["a", "u"], j);
         mig.maintain(end, 0);
-        mig.commit();
         (u, end)
-    };
+    });
 
     // at this point, there's no secondary index on `u`, so any records that are forwarded from `u`
     // must already be present in the one index that `u` has. let's do some writes and check that
@@ -991,11 +939,9 @@ fn replay_during_replay() {
 
     // we now know that u has key a=1 in its index
     // now we add a secondary index on u.u
-    {
-        let mut mig = g.start_migration();
+    g.migrate(|mig| {
         mig.maintain(u, 0);
-        mig.commit();
-    }
+    });
 
     let second = g.get_getter(u).unwrap();
 
@@ -1032,17 +978,13 @@ fn replay_during_replay() {
 fn full_aggregation_with_bogokey() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let base = {
-        let mut mig = g.start_migration();
-        let base = mig.add_ingredient("base", &["x"], distributary::Base::new(vec![1.into()]));
-        mig.commit();
-        base
-    };
+    let base = g.migrate(|mig| {
+        mig.add_ingredient("base", &["x"], distributary::Base::new(vec![1.into()]))
+    });
 
     // add an aggregation over the base with a bogo key.
     // in other words, the aggregation is across all rows.
-    let agg = {
-        let mut mig = g.start_migration();
+    let agg = g.migrate(|mig| {
         let bogo = mig.add_ingredient(
             "bogo",
             &["x", "bogo"],
@@ -1054,9 +996,8 @@ fn full_aggregation_with_bogokey() {
             distributary::Aggregation::COUNT.over(bogo, 0, &[1]),
         );
         mig.maintain(agg, 0);
-        mig.commit();
         agg
-    };
+    });
 
     let aggq = g.get_getter(agg).unwrap();
     let mut base = g.get_mutator(base);
@@ -1092,13 +1033,11 @@ fn full_aggregation_with_bogokey() {
 fn transactional_migration() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let a = {
-        let mut mig = g.start_migration();
+    let a = g.migrate(|mig| {
         let a = mig.add_transactional_base("a", &["a", "b"], distributary::Base::default());
         mig.maintain(a, 0);
-        mig.commit();
         a
-    };
+    });
 
     let mut aq = g.get_getter(a).unwrap();
     let mut muta = g.get_mutator(a);
@@ -1117,13 +1056,11 @@ fn transactional_migration() {
     );
 
     // add unrelated node b in a migration
-    let b = {
-        let mut mig = g.start_migration();
+    let b = g.migrate(|mig| {
         let b = mig.add_transactional_base("b", &["a", "b"], distributary::Base::default());
         mig.maintain(b, 0);
-        mig.commit();
         b
-    };
+    });
 
     let mut bq = g.get_getter(b).unwrap();
     let mut mutb = g.get_mutator(b);
@@ -1141,17 +1078,15 @@ fn transactional_migration() {
         vec![vec![2.into(), 4.into()]]
     );
 
-    let c = {
-        let mut mig = g.start_migration();
+    let c = g.migrate(|mig| {
         let mut emits = HashMap::new();
         emits.insert(a, vec![0, 1]);
         emits.insert(b, vec![0, 1]);
         let u = distributary::Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
         mig.maintain(c, 0);
-        mig.commit();
         c
-    };
+    });
 
     let mut cq = g.get_getter(c).unwrap();
 
@@ -1185,25 +1120,22 @@ fn transactional_migration() {
 fn crossing_migration() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, b) = {
-        let mut mig = g.start_migration();
+    let (a, b) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
-        mig.commit();
         (a, b)
-    };
+    });
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
 
-    let mut mig = g.start_migration();
-    let mut emits = HashMap::new();
-    emits.insert(a, vec![0, 1]);
-    emits.insert(b, vec![0, 1]);
-    let u = distributary::Union::new(emits);
-    let c = mig.add_ingredient("c", &["a", "b"], u);
-    let cq = mig.stream(c);
-
-    mig.commit();
+    let cq = g.migrate(|mig| {
+        let mut emits = HashMap::new();
+        emits.insert(a, vec![0, 1]);
+        emits.insert(b, vec![0, 1]);
+        let u = distributary::Union::new(emits);
+        let c = mig.add_ingredient("c", &["a", "b"], u);
+        mig.stream(c)
+    });
 
     let id: distributary::DataType = 1.into();
 
@@ -1228,13 +1160,11 @@ fn independent_domain_migration() {
 
     // set up graph
     let mut g = distributary::Blender::new();
-    let a = {
-        let mut mig = g.start_migration();
+    let a = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         mig.maintain(a, 0);
-        mig.commit();
         a
-    };
+    });
 
     let aq = g.get_getter(a).unwrap();
     let mut muta = g.get_mutator(a);
@@ -1249,13 +1179,11 @@ fn independent_domain_migration() {
     assert_eq!(aq.lookup(&id, true), Ok(vec![vec![1.into(), 2.into()]]));
 
     // add unrelated node b in a migration
-    let b = {
-        let mut mig = g.start_migration();
+    let b = g.migrate(|mig| {
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
         mig.maintain(b, 0);
-        mig.commit();
         b
-    };
+    });
 
     let bq = g.get_getter(b).unwrap();
     let mut mutb = g.get_mutator(b);
@@ -1274,25 +1202,22 @@ fn independent_domain_migration() {
 fn domain_amend_migration() {
     // set up graph
     let mut g = distributary::Blender::new();
-    let (a, b) = {
-        let mut mig = g.start_migration();
+    let (a, b) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], distributary::Base::default());
         let b = mig.add_ingredient("b", &["a", "b"], distributary::Base::default());
-        mig.commit();
         (a, b)
-    };
+    });
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
 
-    let mut mig = g.start_migration();
-    let mut emits = HashMap::new();
-    emits.insert(a, vec![0, 1]);
-    emits.insert(b, vec![0, 1]);
-    let u = distributary::Union::new(emits);
-    let c = mig.add_ingredient("c", &["a", "b"], u);
-    let cq = mig.stream(c);
-
-    mig.commit();
+    let cq = g.migrate(|mig| {
+        let mut emits = HashMap::new();
+        emits.insert(a, vec![0, 1]);
+        emits.insert(b, vec![0, 1]);
+        let u = distributary::Union::new(emits);
+        let c = mig.add_ingredient("c", &["a", "b"], u);
+        mig.stream(c)
+    });
 
     let id: distributary::DataType = 1.into();
 
@@ -1327,12 +1252,10 @@ fn state_replay_migration_stream() {
     // things come out the other end.
 
     let mut g = distributary::Blender::new();
-    let a = {
-        let mut mig = g.start_migration();
+    let a = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["x", "y"], distributary::Base::default());
-        mig.commit();
         a
-    };
+    });
     let mut muta = g.get_mutator(a);
 
     // make a couple of records
@@ -1340,9 +1263,8 @@ fn state_replay_migration_stream() {
     muta.put(vec![1.into(), "b".into()]).unwrap();
     muta.put(vec![2.into(), "c".into()]).unwrap();
 
-    let (out, b) = {
+    let (out, b) = g.migrate(|mig| {
         // add a new base and a join
-        let mut mig = g.start_migration();
         let b = mig.add_ingredient("b", &["x", "z"], distributary::Base::default());
         use distributary::JoinSource::*;
         let j = distributary::Join::new(
@@ -1356,11 +1278,8 @@ fn state_replay_migration_stream() {
         // we want to observe what comes out of the join
         let out = mig.stream(j);
 
-        // do the migration
-        mig.commit();
-
         (out, b)
-    };
+    });
     let mut mutb = g.get_mutator(b);
 
     // if all went according to plan, the ingress to j's domains hould now contain all the records
@@ -1403,60 +1322,47 @@ fn migration_depends_on_unchanged_domain() {
     // normally wouldn't even look at that part of the data flow graph!
 
     let mut g = distributary::Blender::new();
-    let left = {
-        let mut mig = g.start_migration();
-
+    let left = g.migrate(|mig| {
         // base node, so will be materialized
         let left = mig.add_ingredient("foo", &["a", "b"], distributary::Base::default());
 
         // node in different domain that depends on foo causes egress to be added
         mig.add_ingredient("bar", &["a", "b"], distributary::Identity::new(left));
-
-        // start processing
-        mig.commit();
         left
-    };
+    });
 
-    let mut mig = g.start_migration();
-
-    // joins require their inputs to be materialized
-    // we need a new base as well so we can actually make a join
-    let tmp = mig.add_ingredient("tmp", &["a", "b"], distributary::Base::default());
-    let j = distributary::Join::new(
-        left,
-        tmp,
-        distributary::JoinType::Inner,
-        vec![
-            distributary::JoinSource::B(0, 0),
-            distributary::JoinSource::R(1),
-        ],
-    );
-    mig.add_ingredient("join", &["a", "b"], j);
-
-    // start processing
-    mig.commit();
+    g.migrate(|mig| {
+        // joins require their inputs to be materialized
+        // we need a new base as well so we can actually make a join
+        let tmp = mig.add_ingredient("tmp", &["a", "b"], distributary::Base::default());
+        let j = distributary::Join::new(
+            left,
+            tmp,
+            distributary::JoinType::Inner,
+            vec![
+                distributary::JoinSource::B(0, 0),
+                distributary::JoinSource::R(1),
+            ],
+        );
+        mig.add_ingredient("join", &["a", "b"], j);
+    });
     assert!(true);
 }
 
 fn do_full_vote_migration(old_puts_after: bool) {
     use distributary::{Aggregation, Base, Blender, DataType, Join, JoinType};
     let mut g = Blender::new();
-    let article;
-    let vote;
-    let vc;
-    let end;
-    let (article, vote) = {
+    let (article, vote, vc, end) = g.migrate(|mig| {
         // migrate
-        let mut mig = g.start_migration();
 
         // add article base node
-        article = mig.add_ingredient("article", &["id", "title"], Base::default());
+        let article = mig.add_ingredient("article", &["id", "title"], Base::default());
 
         // add vote base table
-        vote = mig.add_ingredient("vote", &["user", "id"], Base::default().with_key(vec![1]));
+        let vote = mig.add_ingredient("vote", &["user", "id"], Base::default().with_key(vec![1]));
 
         // add vote count
-        vc = mig.add_ingredient(
+        let vc = mig.add_ingredient(
             "votecount",
             &["id", "votes"],
             Aggregation::COUNT.over(vote, 0, &[1]),
@@ -1465,15 +1371,11 @@ fn do_full_vote_migration(old_puts_after: bool) {
         // add final join using first field from article and first from vc
         use distributary::JoinSource::*;
         let j = Join::new(article, vc, JoinType::Left, vec![B(0, 0), L(1), R(1)]);
-        end = mig.add_ingredient("awvc", &["id", "title", "votes"], j);
+        let end = mig.add_ingredient("awvc", &["id", "title", "votes"], j);
 
         mig.maintain(end, 0);
-
-        // start processing
-        mig.commit();
-
-        (article, vote)
-    };
+        (article, vote, vc, end)
+    });
     let mut muta = g.get_mutator(article);
     let mut mutv = g.get_mutator(vote);
 
@@ -1505,9 +1407,7 @@ fn do_full_vote_migration(old_puts_after: bool) {
     }
 
     // migrate
-    let (rating, last) = {
-        let mut mig = g.start_migration();
-
+    let (rating, last) = g.migrate(|mig| {
         // add new "ratings" base table
         let rating = mig.add_ingredient("rating", &["user", "id", "stars"], Base::default());
 
@@ -1532,12 +1432,8 @@ fn do_full_vote_migration(old_puts_after: bool) {
         );
         let newend = mig.add_ingredient("awr", &["id", "title", "ratings", "votes"], j);
         mig.maintain(newend, 0);
-
-        // start processing
-        mig.commit();
-
         (rating, newend)
-    };
+    });
 
     let last = g.get_getter(last).unwrap();
     let mut mutr = g.get_mutator(rating);
@@ -1584,27 +1480,22 @@ fn live_writes() {
     use std::time::Duration;
     use distributary::{Aggregation, Blender, DataType};
     let mut g = Blender::new();
-    let vote;
-    let vc;
-    {
+    let (vote, vc) = g.migrate(|mig| {
         // migrate
-        let mut mig = g.start_migration();
 
         // add vote base table
-        vote = mig.add_ingredient("vote", &["user", "id"], distributary::Base::default());
+        let vote = mig.add_ingredient("vote", &["user", "id"], distributary::Base::default());
 
         // add vote count
-        vc = mig.add_ingredient(
+        let vc = mig.add_ingredient(
             "votecount",
             &["id", "votes"],
             Aggregation::COUNT.over(vote, 0, &[1]),
         );
 
         mig.maintain(vc, 0);
-
-        // start processing
-        mig.commit();
-    }
+        (vote, vc)
+    });
 
     let vc_state = g.get_getter(vc).unwrap();
     let mut add = g.get_mutator(vote);
@@ -1626,17 +1517,15 @@ fn live_writes() {
     thread::sleep(Duration::from_millis(SETTLE_TIME_MS));
 
     // now do a migration that's going to have to copy state
-    let vc2 = {
-        let mut mig = g.start_migration();
+    let vc2 = g.migrate(|mig| {
         let vc2 = mig.add_ingredient(
             "votecount2",
             &["id", "votes"],
             Aggregation::SUM.over(vc, 1, &[0]),
         );
         mig.maintain(vc2, 0);
-        mig.commit();
         vc2
-    };
+    });
 
     let vc2_state = g.get_getter(vc2).unwrap();
 
@@ -1668,14 +1557,12 @@ fn state_replay_migration_query() {
     // are created and populated before the migration, meaning we have to replay through a join.
 
     let mut g = distributary::Blender::new();
-    let (a, b) = {
-        let mut mig = g.start_migration();
+    let (a, b) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["x", "y"], distributary::Base::default());
         let b = mig.add_ingredient("b", &["x", "z"], distributary::Base::default());
-        mig.commit();
 
         (a, b)
-    };
+    });
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
 
@@ -1686,9 +1573,8 @@ fn state_replay_migration_query() {
     mutb.put(vec![1.into(), "n".into()]).unwrap();
     mutb.put(vec![2.into(), "o".into()]).unwrap();
 
-    let out = {
+    let out = g.migrate(|mig| {
         // add join and a reader node
-        let mut mig = g.start_migration();
         use distributary::JoinSource::*;
         let j = distributary::Join::new(
             a,
@@ -1700,12 +1586,8 @@ fn state_replay_migration_query() {
 
         // we want to observe what comes out of the join
         mig.maintain(j, 0);
-
-        // do the migration
-        mig.commit();
-
         j
-    };
+    });
     let out = g.get_getter(out).unwrap();
     thread::sleep(time::Duration::from_millis(SETTLE_TIME_MS));
 
@@ -1741,11 +1623,9 @@ fn recipe_activates() {
     assert_eq!(r.prior(), None);
 
     let mut g = distributary::Blender::new();
-    {
-        let mut mig = g.start_migration();
-        assert!(r.activate(&mut mig, false).is_ok());
-        mig.commit();
-    }
+    g.migrate(|mig| {
+        assert!(r.activate(mig, false).is_ok());
+    });
     // one base node
     assert_eq!(g.inputs().len(), 1);
 }
@@ -1759,11 +1639,9 @@ fn recipe_activates_and_migrates() {
     assert_eq!(r.prior(), None);
 
     let mut g = distributary::Blender::new();
-    {
-        let mut mig = g.start_migration();
-        assert!(r.activate(&mut mig, false).is_ok());
-        mig.commit();
-    }
+    g.migrate(|mig| {
+        assert!(r.activate(mig, false).is_ok());
+    });
     // one base node
     assert_eq!(g.inputs().len(), 1);
 
@@ -1775,11 +1653,9 @@ fn recipe_activates_and_migrates() {
     assert_eq!(r1.version(), 1);
     assert_eq!(r1.expressions().len(), 3);
     assert_eq!(**r1.prior().unwrap(), r_copy);
-    {
-        let mut mig = g.start_migration();
-        assert!(r1.activate(&mut mig, false).is_ok());
-        mig.commit();
-    }
+    g.migrate(|mig| {
+        assert!(r1.activate(mig, false).is_ok());
+    });
     // still one base node
     assert_eq!(g.inputs().len(), 1);
     // two leaf nodes
@@ -1796,11 +1672,9 @@ fn recipe_activates_and_migrates_with_join() {
     assert_eq!(r.prior(), None);
 
     let mut g = distributary::Blender::new();
-    {
-        let mut mig = g.start_migration();
-        assert!(r.activate(&mut mig, false).is_ok());
-        mig.commit();
-    }
+    g.migrate(|mig| {
+        assert!(r.activate(mig, false).is_ok());
+    });
     // two base nodes
     assert_eq!(g.inputs().len(), 2);
 
@@ -1811,11 +1685,9 @@ fn recipe_activates_and_migrates_with_join() {
     assert_eq!(r1.version(), 1);
     assert_eq!(r1.expressions().len(), 3);
     assert_eq!(**r1.prior().unwrap(), r_copy);
-    {
-        let mut mig = g.start_migration();
-        assert!(r1.activate(&mut mig, false).is_ok());
-        mig.commit();
-    }
+    g.migrate(|mig| {
+        assert!(r1.activate(mig, false).is_ok());
+    });
     // still two base nodes
     assert_eq!(g.inputs().len(), 2);
     // one leaf node
@@ -1830,9 +1702,7 @@ fn finkelstein1982_queries() {
     // set up graph
     let mut g = distributary::Blender::new();
     let mut inc = distributary::SqlIncorporator::default();
-    {
-        let mut mig = g.start_migration();
-
+    g.migrate(|mig| {
         let mut f = File::open("tests/finkelstein82.txt").unwrap();
         let mut s = String::new();
 
@@ -1849,10 +1719,9 @@ fn finkelstein1982_queries() {
 
         // Add them one by one
         for q in lines.iter() {
-            assert!(inc.add_query(q, None, &mut mig).is_ok());
+            assert!(inc.add_query(q, None, mig).is_ok());
         }
-        mig.commit();
-    }
+    });
 
     println!("{}", g);
 }
@@ -1865,9 +1734,7 @@ fn tpc_w() {
     // set up graph
     let mut g = distributary::Blender::new();
     let mut r = distributary::Recipe::blank(None);
-    {
-        let mut mig = g.start_migration();
-
+    g.migrate(|mig| {
         let mut f = File::open("tests/tpc-w-queries.txt").unwrap();
         let mut s = String::new();
 
@@ -1888,7 +1755,7 @@ fn tpc_w() {
             let or = r.clone();
             r = match r.extend(q) {
                 Ok(mut nr) => {
-                    assert!(nr.activate(&mut mig, false).is_ok());
+                    assert!(nr.activate(mig, false).is_ok());
                     nr
                 }
                 Err(e) => {
@@ -1897,9 +1764,7 @@ fn tpc_w() {
                 }
             }
         }
-
-        mig.commit();
-    }
+    });
 
     println!("{}", g);
 }


### PR DESCRIPTION
I've been wanting to make this change for a while now.

Since a migration mutably borrows the `Blender`, the migration usually has to happen in its own (useless) scope, at least without NLL. This is annoying. Furthermore, the requirement to call `mig.commit()` is silly since we (at least atm) cannot abort a migration.

This patch changes migrations to instead happen in a closure, which essentially wraps the same things every caller had to do previously.