### PR TITLE
Fix example error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,6 @@ path = "src/lib.rs"
 
 [[example]]
 name = "basic-recipe"
-required-features = ["binaries"]
 
 [[bin]]
 name = "web"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ Run the test suite
 $ cargo test
 ```
 
-And build the documentation (in `target/doc/distributary/`)
+Build the documentation (in `target/doc/distributary/`)
 ```console
 $ cargo doc
+```
+
+And run the example
+```console
+$ cargo run --example basic-recipe
 ```
 
 ## Benchmarks

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -6,7 +6,7 @@ use std::{thread, time};
 use distributary::{Blender, Recipe};
 use backend::Backend;
 
-fn load_recipe() -> Result<Backend, String> {
+fn load_recipe() -> Backend {
     // inline recipe definition
     let sql = "# base tables
                CREATE TABLE Article (aid int, title varchar(255), \
@@ -26,21 +26,17 @@ fn load_recipe() -> Result<Backend, String> {
 
     let recipe = soup.migrate(|mig| {
         // install recipe
-        match Recipe::from_str(&sql, None) {
-            Ok(mut recipe) => {
-                recipe.activate(mig, false)?;
-                recipe
-            }
-            Err(e) => return Err(e),
-        }
+        let mut recipe = Recipe::from_str(&sql, None).unwrap();
+        recipe.activate(mig, false).unwrap();
         // return brings up new graph for processing
+        recipe
     });
 
-    Ok(Backend::new(soup, recipe))
+    Backend::new(soup, recipe)
 }
 
 fn main() {
-    let mut backend = load_recipe().unwrap();
+    let mut backend = load_recipe();
 
     println!("Soup graph:\n{}", backend.soup);
 


### PR DESCRIPTION
This fixes a compile error in the example from the change to `.migrate` closures (`return Err(e)` would be a return for the closure, not the entire `load_recipe` function).

Also removes `required-features = ["binaries"]` from the example to make `cargo test` check it for compile errors, and adds a small note to the README about `cargo run --example basic-recipe`.