### PR TITLE
Upgrade timekeeper to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tarpc 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tarpc-plugins 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "timekeeper 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "timekeeper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1533,8 +1533,11 @@ dependencies = [
 
 [[package]]
 name = "timekeeper"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tokio-core"
@@ -1946,7 +1949,7 @@ dependencies = [
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum tiberius 0.2.2 (git+https://github.com/ms705/tiberius/)" = "<none>"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
-"checksum timekeeper 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fe331f71ab799ac67d61d5b3a2d87e13579b66616e49c21f4d67696e0f326dd1"
+"checksum timekeeper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5bb9b8201d620a812b747fd1e8c523db6d7961ec3aa0915772256fee504bce7"
 "checksum tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c843a027f7c1df5f81e7734a0df3f67bf329411781ebf36393ce67beef6071e3"
 "checksum tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ab83e7adb5677e42e405fa4ceff75659d93c4d7d7dd22f52fcec59ee9f02af"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,8 @@ features = ["rustc_json_body", "multipart"]
 optional = true
 
 [dependencies.timekeeper]
-version = "0.2.4"
+version = "0.3.0"
 default-features = false
-# for Mac OS X build
-# git = "https://github.com/ms705/timekeeper"
 
 [dev-dependencies]
 backtrace = { version = "0.3.2", features = ["serialize-serde"] }


### PR DESCRIPTION
Also removes the macOS comment, since that now works out of the box.