### PR TITLE
Recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-soup-log-*.json
+*-log-*.json
 *.png
 *.log
 plotting/*.png

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ name = "aho-corasick"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,7 +397,7 @@ name = "distributary"
 version = "0.1.0"
 dependencies = [
  "arccstr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "buf_redux 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -433,6 +433,7 @@ dependencies = [
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tarpc 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tarpc-plugins 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "timekeeper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -992,7 +993,7 @@ name = "nom"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1232,7 +1233,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1905,7 +1906,7 @@ dependencies = [
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 "checksum arccstr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "71b8d6328e2abfe1cdb1f88a22098bd4c318539603234a4c60db3f5200ec17a4"
-"checksum arrayvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6f9bb6deaad90a5bd12b5af488483c8bb318b4b5c1bf836d0148a1c0f3d9da2e"
+"checksum arrayvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1c0250693b17316353df525fb088da32a8c18f84eb65d113dde31f5a76ed17b6"
 "checksum atomic-option 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0db678acb667b525ac40a324fc5f7d3390e29239b31c7327bb8157f5b4fff593"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
@@ -1983,7 +1984,7 @@ dependencies = [
 "checksum md5 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "11f2f3240857d306c26118e2e92a5eaf8990df379e3d96573ee6c92cdbf58a81"
 "checksum memcached-rs 0.1.2 (git+https://github.com/jonhoo/memcached-rs.git?branch=expose-multi)" = "<none>"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum mime_guess 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbee1a836f344ac39d4a59bfe7be2bd3150353ff71678afb740216f8270b333e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ name = "aho-corasick"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,7 +397,7 @@ name = "distributary"
 version = "0.1.0"
 dependencies = [
  "arccstr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "buf_redux 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -993,7 +993,7 @@ name = "nom"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1233,7 +1233,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1906,7 +1906,7 @@ dependencies = [
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 "checksum arccstr 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "71b8d6328e2abfe1cdb1f88a22098bd4c318539603234a4c60db3f5200ec17a4"
-"checksum arrayvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1c0250693b17316353df525fb088da32a8c18f84eb65d113dde31f5a76ed17b6"
+"checksum arrayvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6f9bb6deaad90a5bd12b5af488483c8bb318b4b5c1bf836d0148a1c0f3d9da2e"
 "checksum atomic-option 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0db678acb667b525ac40a324fc5f7d3390e29239b31c7327bb8157f5b4fff593"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
@@ -1984,7 +1984,7 @@ dependencies = [
 "checksum md5 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "11f2f3240857d306c26118e2e92a5eaf8990df379e3d96573ee6c92cdbf58a81"
 "checksum memcached-rs 0.1.2 (git+https://github.com/jonhoo/memcached-rs.git?branch=expose-multi)" = "<none>"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum mime_guess 1.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbee1a836f344ac39d4a59bfe7be2bd3150353ff71678afb740216f8270b333e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "evmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hurdles 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -586,6 +587,11 @@ dependencies = [
 [[package]]
 name = "gcc"
 version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "glob"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1959,6 +1965,7 @@ dependencies = [
 "checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
 "checksum futures-state-stream 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2776ce933858e98061287622bf43051a7122ce7aa9ac02459ff2d4b9957e2191"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hdrsample 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "287e16cba33f96bc686f594a772165f5998a70ea7bbae08041a940eb8ffed4e6"
 "checksum hostname 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d865f01509e69c001c31b8c341607d93caef4ecf6836ffee39a1702430147943"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,6 @@ dependencies = [
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tarpc 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tarpc-plugins 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "timekeeper 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ binaries = ["default"]
 generate_mysql_tests = ["default"]
 
 [dependencies]
-arccstr = "1.0.2"
+arccstr = "1.0.3"
 arrayvec = "0.4.0"
 bincode = "0.9.0"
 buf_redux = "0.6.1"
@@ -78,6 +78,7 @@ default-features = false
 backtrace = { version = "0.3.2", features = ["serialize-serde"] }
 toml = "0.4.1"
 diff = "0.1.10"
+time = "0.1.38"
 
 [profile.release]
 debug=true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ backtrace = { version = "0.3.2", features = ["serialize-serde"] }
 toml = "0.4.1"
 diff = "0.1.10"
 time = "0.1.38"
+glob = "0.2.11"
 
 [profile.release]
 debug=true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ default-features = false
 backtrace = { version = "0.3.2", features = ["serialize-serde"] }
 toml = "0.4.1"
 diff = "0.1.10"
-time = "0.1.38"
 glob = "0.2.11"
 
 [profile.release]

--- a/benchmarks/vote/vote-server.rs
+++ b/benchmarks/vote/vote-server.rs
@@ -67,8 +67,12 @@ fn main() {
 
     println!("Attempting to start soup on {}", addr);
 
-    let persistence_params =
-        distributary::PersistenceParameters::new(durability, 512, time::Duration::from_millis(1));
+    let persistence_params = distributary::PersistenceParameters::new(
+        durability,
+        512,
+        time::Duration::from_millis(1),
+        Some(String::from("vote")),
+    );
 
     let sock_addr: SocketAddr = addr.parse()
         .expect("ADDR must be a valid HOST:PORT combination");

--- a/benchmarks/vote/vote.rs
+++ b/benchmarks/vote/vote.rs
@@ -249,7 +249,12 @@ fn main() {
         DurabilityMode::MemoryOnly
     };
 
-    let persistence_params = PersistenceParameters::new(mode, queue_length, flush_timeout);
+    let persistence_params = PersistenceParameters::new(
+        mode,
+        queue_length,
+        flush_timeout,
+        Some(String::from("vote")),
+    );
 
     // setup db
     let mut s = graph::Setup::default();

--- a/dataflow/src/checktable/mod.rs
+++ b/dataflow/src/checktable/mod.rs
@@ -6,7 +6,7 @@
 
 use petgraph::graph::NodeIndex;
 
-use std::collections::HashMap;
+use std::collections::hash_map::{Entry, HashMap};
 use std::fmt;
 use std::fmt::Debug;
 
@@ -283,6 +283,40 @@ impl CheckTable {
                 }
             }
         }
+    }
+
+    pub fn recover(
+        &mut self,
+        base: NodeIndex,
+        columns: usize,
+    ) -> (i64, Option<Box<HashMap<domain::Index, i64>>>) {
+        // Take timestamp
+        let ts = self.next_timestamp;
+        self.next_timestamp += 1;
+
+        // Compute the previous timestamp that each domain will see before getting this one
+        let prev_times = self.compute_previous_timestamps(Some(base));
+
+        // Update checktables
+        self.last_base = Some(base);
+        self.toplevel.insert(base, ts);
+
+        // Set the timestamp for each column:
+        let t = &mut self.granular.entry(base).or_default();
+        for i in 0..columns {
+            match t.entry(i) {
+                Entry::Occupied(mut entry) => {
+                    let g = entry.get_mut();
+                    assert!(g.0.is_empty(), "checktable should be empty before recovery");
+                    g.1 = ts;
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert((HashMap::new(), ts));
+                }
+            }
+        }
+
+        (ts, prev_times)
     }
 
     pub fn apply_unconditional(

--- a/dataflow/src/checktable/mod.rs
+++ b/dataflow/src/checktable/mod.rs
@@ -285,6 +285,8 @@ impl CheckTable {
         }
     }
 
+    // Reserve a timestamp for the given base node, and update each column to said timestamp.
+    // This should be called for each batch of recovery updates.
     pub fn recover(&mut self, base: NodeIndex) -> (i64, Option<Box<HashMap<domain::Index, i64>>>) {
         // Take timestamp
         let ts = self.next_timestamp;

--- a/dataflow/src/checktable/service.rs
+++ b/dataflow/src/checktable/service.rs
@@ -29,8 +29,7 @@ pub struct TimestampReply {
 
 service! {
     rpc apply_batch(request: TimestampRequest) -> Option<TimestampReply>;
-    rpc recover(base: NodeIndex, columns: usize)
-                       -> (i64, Option<Box<HashMap<domain::Index, i64>>>);
+    rpc recover(base: NodeIndex) -> (i64, Option<Box<HashMap<domain::Index, i64>>>);
     rpc claim_replay_timestamp(tag: Tag) -> (i64, Option<Box<HashMap<domain::Index, i64>>>);
     rpc track(token_generator: TokenGenerator);
     rpc perform_migration(deps: HashMap<domain::Index, (IngressFromBase, EgressForBase)>)
@@ -110,12 +109,7 @@ impl FutureService for CheckTableServer {
     }
 
     type RecoverFut = Result<(i64, Option<Box<HashMap<domain::Index, i64>>>), Never>;
-    fn recover(&self, base: NodeIndex, columns: usize) -> Self::RecoverFut {
-        Ok(
-            self.checktable
-                .lock()
-                .unwrap()
-                .recover(base, columns),
-        )
+    fn recover(&self, base: NodeIndex) -> Self::RecoverFut {
+        Ok(self.checktable.lock().unwrap().recover(base))
     }
 }

--- a/dataflow/src/checktable/service.rs
+++ b/dataflow/src/checktable/service.rs
@@ -29,6 +29,8 @@ pub struct TimestampReply {
 
 service! {
     rpc apply_batch(request: TimestampRequest) -> Option<TimestampReply>;
+    rpc recover(base: NodeIndex, columns: usize)
+                       -> (i64, Option<Box<HashMap<domain::Index, i64>>>);
     rpc claim_replay_timestamp(tag: Tag) -> (i64, Option<Box<HashMap<domain::Index, i64>>>);
     rpc track(token_generator: TokenGenerator);
     rpc perform_migration(deps: HashMap<domain::Index, (IngressFromBase, EgressForBase)>)
@@ -105,5 +107,15 @@ impl FutureService for CheckTableServer {
     type ValidateTokenFut = Result<bool, Never>;
     fn validate_token(&self, token: Token) -> Self::ValidateTokenFut {
         Ok(self.checktable.lock().unwrap().validate_token(&token))
+    }
+
+    type RecoverFut = Result<(i64, Option<Box<HashMap<domain::Index, i64>>>), Never>;
+    fn recover(&self, base: NodeIndex, columns: usize) -> Self::RecoverFut {
+        Ok(
+            self.checktable
+                .lock()
+                .unwrap()
+                .recover(base, columns),
+        )
     }
 }

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -5,7 +5,6 @@ use std::thread;
 use std::time;
 use std::io::{BufRead, BufReader};
 use std::fs::File;
-use std::path::PathBuf;
 use std::collections::hash_map::Entry;
 use std::rc::Rc;
 
@@ -1579,14 +1578,8 @@ impl Domain {
             .map(|(index, _node)| index)
             .collect::<Vec<_>>();
 
-        for index in indices {
-            let path = PathBuf::from(&format!(
-                "soup-log-{}_{}-{}.json",
-                self.index.index(),
-                self.shard.unwrap_or(0),
-                index.id(),
-            ));
-
+        for node_index in indices {
+            let path = persistence::log_path(&node_index, self.index, self.shard.unwrap_or(0));
             if !path.exists() {
                 debug!(
                     self.log,
@@ -1609,7 +1602,7 @@ impl Domain {
                 .for_each(|records| {
                     let packet = box Packet::Message {
                         data: records,
-                        link: Link::new(index, index),
+                        link: Link::new(node_index, node_index),
                         tracer: None,
                     };
 

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1583,8 +1583,6 @@ impl Domain {
             .for_each(|packet| self.handle(packet));
 
         self.control_reply_tx
-            .as_ref()
-            .unwrap()
             .send(ControlReplyPacket::ack())
             .unwrap();
     }

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1570,18 +1570,15 @@ impl Domain {
     }
 
     fn handle_recovery(&mut self) {
-        let group_commit_queues = persistence::GroupCommitQueueSet::new(
+        let packets = persistence::retrieve_recovery_packets(
+            &self.nodes,
             self.index,
             self.shard.unwrap_or(0),
             &self.persistence_parameters,
             self.transaction_state.get_checktable().clone(),
         );
 
-        group_commit_queues
-            .retrieve_recovery_packets(&self.nodes)
-            .into_iter()
-            .for_each(|packet| self.handle(packet));
-
+        packets.into_iter().for_each(|packet| self.handle(packet));
         self.control_reply_tx
             .send(ControlReplyPacket::ack())
             .unwrap();

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1593,7 +1593,15 @@ impl Domain {
 
             let file = match File::open(&path) {
                 Ok(f) => f,
-                Err(ref e) if e.kind() == ErrorKind::NotFound => continue,
+                Err(ref e) if e.kind() == ErrorKind::NotFound => {
+                    warn!(
+                        self.log,
+                        "No log file found for node {}, starting out empty",
+                        local_addr
+                    );
+
+                    continue;
+                }
                 Err(e) => panic!("Could not open log file {:?}: {}", path, e),
             };
 

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1575,16 +1575,16 @@ impl Domain {
     }
 
     fn handle_recovery(&mut self) {
+        let checktable = self.transaction_state.get_checktable();
         let node_info: Vec<_> = self.nodes
             .iter()
             .map(|(index, node)| {
                 let n = node.borrow();
-                (index.clone(), n.global_addr(), n.is_transactional())
+                (index, n.global_addr(), n.is_transactional())
             })
             .collect();
 
         for (local_addr, global_addr, is_transactional) in node_info {
-            let checktable = self.transaction_state.get_checktable();
             let path = self.persistence_parameters.log_path(
                 &local_addr,
                 self.index,
@@ -1608,7 +1608,8 @@ impl Domain {
             BufReader::new(file)
                 .lines()
                 .filter_map(|line| {
-                    let line = line.unwrap();
+                    let line = line
+                        .expect(&format!("Failed to read line from log file: {:?}", path));
                     let entries: Result<Vec<Records>, _> = serde_json::from_str(&line);
                     entries.ok()
                 })

--- a/dataflow/src/payload.rs
+++ b/dataflow/src/payload.rs
@@ -223,6 +223,9 @@ pub enum Packet {
     /// A packet used solely to drive the event loop forward.
     Spin,
 
+    /// Signal that a base node's domain should start replaying logs.
+    StartRecovery,
+
     // Transaction time messages
     //
     /// Instruct domain to flush pending transactions and notify upon completion. `prev_ts` is the

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -129,13 +129,8 @@ impl GroupCommitQueueSet {
             node.id()
         );
 
-        // TODO(jmftrindade): Current semantics is to overwrite an existing log.
-        // Once we have recovery code, we obviously do not want to overwrite this
-        // log before recovering.
         let file = OpenOptions::new()
-            .read(false)
-            .append(false)
-            .write(true)
+            .append(true)
             .create(true)
             .open(PathBuf::from(&filename))
             .unwrap();

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -205,6 +205,9 @@ impl GroupCommitQueueSet {
                         })
                         .collect();
                     serde_json::to_writer(&mut file, &data_to_flush).unwrap();
+                    // Separate log flushes with a newline so that the
+                    // file can be easily parsed later on:
+                    writeln!(&mut file, "").unwrap();
                 }
 
                 file.flush().unwrap();

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -129,11 +129,12 @@ pub fn retrieve_recovery_packets(
 
         BufReader::new(file)
             .lines()
-            .flat_map(|line| {
+            .filter_map(|line| {
                 let line = line.unwrap();
-                let entries: Vec<Records> = serde_json::from_str(&line).unwrap();
-                entries
+                let entries: Result<Vec<Records>, _> = serde_json::from_str(&line);
+                entries.ok()
             })
+            .flat_map(|r| r)
             .enumerate()
             .map(|(i, data)| {
                 let link = Link::new(*local_addr, *local_addr);

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -43,12 +43,6 @@ pub struct Parameters {
     pub log_prefix: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-enum PacketType {
-    Message,
-    Transaction,
-}
-
 impl Default for Parameters {
     fn default() -> Self {
         Self {

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -149,10 +149,7 @@ pub fn retrieve_recovery_packets(
             .map(|data| {
                 let link = Link::new(*local_addr, *local_addr);
                 if node.is_transactional() {
-                    let (ts, prevs) = checktable
-                        .recover(global_addr, node.fields().len())
-                        .unwrap();
-
+                    let (ts, prevs) = checktable.recover(global_addr).unwrap();
                     Packet::Transaction {
                         link,
                         data,

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -30,8 +30,9 @@ fn main() {
 
     // set up Soup via recipe
     let blender = ControllerBuilder::default().build();
-    blender.set_persistence(persistence_params);
+    blender.with_persistence_options(persistence_params);
     blender.install_recipe(sql.to_owned());
+    blender.recover();
 
     // Get mutators and getter.
     let inputs = blender.inputs();

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -26,6 +26,7 @@ fn main() {
         distributary::DurabilityMode::Permanent,
         512,
         Duration::from_millis(1),
+        Some(String::from("example")),
     );
 
     // set up Soup via recipe

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -56,17 +56,6 @@ fn main() {
     println!("Casting vote...");
     let uid = time::get_time().sec;
     vote.put(vec![aid.into(), uid.into()]).unwrap();
-    article
-        .put(vec![
-            1.into(),
-            "test title".into(),
-            "http://csail.mit.edu".into(),
-        ])
-        .unwrap();
-
-    vote.put(vec![1.into(), 42.into()]).unwrap();
-    vote.put(vec![1.into(), 43.into()]).unwrap();
-    vote.put(vec![1.into(), 44.into()]).unwrap();
 
     println!("Finished writing! Let's wait for things to propagate...");
     thread::sleep(Duration::from_millis(1000));

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -1,10 +1,9 @@
 extern crate distributary;
-extern crate time;
 
 use distributary::ControllerBuilder;
 
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 fn main() {
     // inline recipe definition
@@ -57,7 +56,10 @@ fn main() {
 
     // Then create a new vote:
     println!("Casting vote...");
-    let uid = time::get_time().sec;
+    let uid = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
     vote.put(vec![aid.into(), uid.into()]).unwrap();
 
     println!("Finished writing! Let's wait for things to propagate...");

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -1,8 +1,6 @@
 extern crate distributary;
 extern crate time;
 
-mod backend;
-
 use distributary::ControllerBuilder;
 
 use std::thread;
@@ -30,8 +28,10 @@ fn main() {
     );
 
     // set up Soup via recipe
-    let blender = ControllerBuilder::default().build();
-    blender.with_persistence_options(persistence_params);
+    let mut builder = ControllerBuilder::default();
+    builder.set_persistence(persistence_params);
+
+    let mut blender = builder.build();
     blender.install_recipe(sql.to_owned());
     blender.recover();
 
@@ -45,7 +45,7 @@ fn main() {
     println!("Creating article...");
     let aid = 1;
     // Make sure the article exists:
-    if article.lookup(&aid.into(), true).is_empty() {
+    if awvc.lookup(&aid.into(), true).unwrap().is_empty() {
         println!("Creating new article...");
         let title = "test title";
         let url = "http://pdos.csail.mit.edu";

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -34,6 +34,7 @@ fn main() {
     let mut blender = builder.build();
     blender.install_recipe(sql.to_owned());
     blender.recover();
+    thread::sleep(Duration::from_millis(1000));
 
     // Get mutators and getter.
     let inputs = blender.inputs();

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -20,10 +20,6 @@ use futures::{Future, Stream};
 use hyper::Client;
 use mio::net::TcpListener;
 
-use std::io::{BufRead, BufReader};
-use std::fs::File;
-use std::path::PathBuf;
-
 use std::time;
 use std::fmt;
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -527,11 +527,6 @@ impl ControllerInner {
             let node = &self.ingredients[*index];
             let domain = self.domains.get_mut(&node.domain()).unwrap();
             domain.send(box payload::Packet::StartRecovery).unwrap();
-        }
-
-        for (_name, index) in self.inputs(()).iter() {
-            let node = &self.ingredients[*index];
-            let domain = self.domains.get_mut(&node.domain()).unwrap();
             domain.wait_for_ack().unwrap();
         }
     }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -19,11 +19,6 @@ use std::{fmt, io, thread, time};
 use futures::{Future, Stream};
 use hyper::Client;
 use mio::net::TcpListener;
-
-use std::time;
-use std::fmt;
-
-use slog;
 use petgraph;
 use petgraph::visit::Bfs;
 use petgraph::graph::NodeIndex;
@@ -532,9 +527,13 @@ impl ControllerInner {
             .map(|&(_input, ref node)| node.domain())
             .collect::<Vec<_>>();
 
-        for index in indices {
+        for index in indices.clone() {
             let domain = self.domains.get_mut(&index).unwrap();
             domain.send(box payload::Packet::StartRecovery).unwrap();
+        }
+
+        for index in indices {
+            let domain = self.domains.get_mut(&index).unwrap();
             domain.wait_for_ack().unwrap();
         }
     }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -523,21 +523,15 @@ impl ControllerInner {
     /// StartRecovery packet to each base node domain.
     pub fn recover(&mut self, _: ()) {
         info!(self.log, "Recovering from log");
-        let indices = self.inputs(())
-            .iter()
-            .map(|(_name, index)| {
-                let node = &self.ingredients[*index];
-                node.domain()
-            })
-            .collect::<Vec<_>>();
-
-        for index in indices.clone() {
-            let domain = self.domains.get_mut(&index).unwrap();
+        for (_name, index) in self.inputs(()).iter() {
+            let node = &self.ingredients[*index];
+            let domain = self.domains.get_mut(&node.domain()).unwrap();
             domain.send(box payload::Packet::StartRecovery).unwrap();
         }
 
-        for index in indices {
-            let domain = self.domains.get_mut(&index).unwrap();
+        for (_name, index) in self.inputs(()).iter() {
+            let node = &self.ingredients[*index];
+            let domain = self.domains.get_mut(&node.domain()).unwrap();
             domain.wait_for_ack().unwrap();
         }
     }

--- a/src/controller/sql/query_graph.rs
+++ b/src/controller/sql/query_graph.rs
@@ -363,9 +363,11 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
     let mut qg = QueryGraph::new();
 
     // a handy closure for making new relation nodes
-    let new_node =
-        |rel: String, preds: Vec<ConditionExpression>, st: &SelectStatement| -> QueryGraphNode {
-            QueryGraphNode {
+    let new_node = |rel: String,
+                    preds: Vec<ConditionExpression>,
+                    st: &SelectStatement|
+     -> QueryGraphNode {
+        QueryGraphNode {
             rel_name: rel.clone(),
             predicates: preds,
             columns: st.fields
@@ -400,7 +402,7 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
                 .collect(),
             parameters: Vec::new(),
         }
-        };
+    };
 
     // 1. Add any relations mentioned in the query to the query graph.
     // This is needed so that we don't end up with an empty query graph when there are no

--- a/src/controller/sql/query_graph.rs
+++ b/src/controller/sql/query_graph.rs
@@ -363,11 +363,9 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
     let mut qg = QueryGraph::new();
 
     // a handy closure for making new relation nodes
-    let new_node = |rel: String,
-                    preds: Vec<ConditionExpression>,
-                    st: &SelectStatement|
-     -> QueryGraphNode {
-        QueryGraphNode {
+    let new_node =
+        |rel: String, preds: Vec<ConditionExpression>, st: &SelectStatement| -> QueryGraphNode {
+            QueryGraphNode {
             rel_name: rel.clone(),
             predicates: preds,
             columns: st.fields
@@ -402,7 +400,7 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
                 .collect(),
             parameters: Vec::new(),
         }
-    };
+        };
 
     // 1. Add any relations mentioned in the query to the query graph.
     // This is needed so that we don't end up with an empty query graph when there are no

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -421,7 +421,6 @@ fn it_recovers_persisted_logs() {
 
     // Recover and let the writes propagate:
     g.recover();
-    sleep();
 
     for i in 1..10 {
         let price = i * 10;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -477,11 +477,11 @@ fn it_recovers_persisted_logs_w_transactions() {
     g.recover();
 
     for i in 1..10 {
-        let price = i * 10;
+        let b = i * 10;
         let (result, _token) = getter.transactional_lookup(&i.into()).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0][0], i.into());
-        assert_eq!(result[0][1], price.into());
+        assert_eq!(result[0][1], b.into());
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 extern crate glob;
-extern crate time;
 
 use core::{DataType, Datas};
 use dataflow::DomainBuilder;
@@ -30,7 +29,7 @@ use controller::recipe::{ActivationResult, Recipe};
 use controller::sql::reuse::ReuseConfigType;
 use controller::sql::{SqlIncorporator, ToFlowParts};
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::thread;
 use std::sync::mpsc;
 use std::env;
@@ -42,8 +41,13 @@ const DEFAULT_SETTLE_TIME_MS: u64 = 100;
 // Suffixes the given log prefix with a timestamp, ensuring that
 // subsequent test runs do not reuse log files in the case of failures.
 fn get_log_name(prefix: &str) -> String {
-    let current_time = time::get_time();
-    format!("{}-{}-{}", prefix, current_time.sec, current_time.nsec)
+    let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    format!(
+        "{}-{}-{}",
+        prefix,
+        current_time.as_secs(),
+        current_time.subsec_nanos()
+    )
 }
 
 // Ensures correct handling of log file names, by deleting used log files in Drop.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -423,6 +423,7 @@ fn it_recovers_persisted_logs() {
 
     // Recover and let the writes propagate:
     g.recover(());
+    sleep();
 
     for i in 1..10 {
         let price = i * 10;
@@ -474,6 +475,7 @@ fn it_recovers_persisted_logs_w_transactions() {
 
     // Recover and let the writes propagate:
     g.recover(());
+    sleep();
 
     for i in 1..10 {
         let b = i * 10;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,8 @@
+<<<<<<< HEAD
+=======
+extern crate time;
+
+>>>>>>> Suffix test log files with a timestamp
 use core::{DataType, Datas};
 use dataflow::DomainBuilder;
 use dataflow::backlog::SingleReadHandle;
@@ -27,7 +32,7 @@ use controller::recipe::{ActivationResult, Recipe};
 use controller::sql::reuse::ReuseConfigType;
 use controller::sql::{SqlIncorporator, ToFlowParts};
 
-use std::time;
+use std::time::Duration;
 use std::thread;
 use std::sync::mpsc;
 use std::env;
@@ -36,13 +41,20 @@ use std::collections::HashMap;
 
 const DEFAULT_SETTLE_TIME_MS: u64 = 100;
 
-fn get_settle_time() -> time::Duration {
+fn get_settle_time() -> Duration {
     let settle_time: u64 = match env::var("SETTLE_TIME") {
         Ok(value) => value.parse().unwrap(),
         Err(_) => DEFAULT_SETTLE_TIME_MS,
     };
 
-    time::Duration::from_millis(settle_time)
+    Duration::from_millis(settle_time)
+}
+
+// Suffixes the given log base with a timestamp, ensuring that
+// subsequent test runs do not reuse log files in the case of failures:
+fn get_log_name(base: &str) -> String {
+    let current_time = time::get_time();
+    format!("{}-{}-{}", base, current_time.sec, current_time.nsec)
 }
 
 // Sleeps for either DEFAULT_SETTLE_TIME_MS milliseconds, or
@@ -58,8 +70,8 @@ fn it_works_basic() {
     let pparams = PersistenceParameters::new(
         DurabilityMode::DeleteOnExit,
         128,
-        time::Duration::from_millis(1),
-        Some(String::from("it_works_basic")),
+        Duration::from_millis(1),
+        Some(get_log_name("it_works_basic")),
     );
     g.with_persistence_options(pparams);
     let (a, b, c) = g.migrate(|mig| {
@@ -378,13 +390,14 @@ fn it_works_with_arithmetic_aliases() {
 
 #[test]
 fn it_recovers_persisted_logs() {
+    let log_name = get_log_name("it_recovers_persisted_logs");
     let setup = || {
         let mut g = ControllerBuilder::default().build_inner();
         let pparams = PersistenceParameters::new(
             DurabilityMode::DeleteOnExit,
             128,
-            time::Duration::from_millis(1),
-            Some(String::from("it_recovers_persisted_logs")),
+            Duration::from_millis(1),
+            Some(log_name.clone()),
         );
         g.with_persistence_options(pparams);
 
@@ -435,13 +448,14 @@ fn it_recovers_persisted_logs() {
 
 #[test]
 fn it_recovers_persisted_logs_w_multiple_nodes() {
+    let log_name = get_log_name("it_recovers_persisted_logs_w_multiple_nodes");
     let setup = || {
         let mut g = ControllerBuilder::default().build_inner();
         let pparams = PersistenceParameters::new(
             DurabilityMode::DeleteOnExit,
             128,
-            time::Duration::from_millis(1),
-            Some(String::from("it_recovers_persisted_logs_w_multiple_nodes")),
+            Duration::from_millis(1),
+            Some(log_name.clone()),
         );
         g.with_persistence_options(pparams);
 
@@ -492,13 +506,14 @@ fn it_recovers_persisted_logs_w_multiple_nodes() {
 
 #[test]
 fn it_recovers_persisted_logs_w_transactions() {
+    let log_name = get_log_name("it_recovers_persisted_logs");
     let setup = || {
         let mut g = ControllerBuilder::default().build_inner();
         let pparams = PersistenceParameters::new(
             DurabilityMode::DeleteOnExit,
             128,
-            time::Duration::from_millis(1),
-            Some(String::from("it_recovers_persisted_logs_w_transactions")),
+            Duration::from_millis(1),
+            Some(log_name.clone()),
         );
         g.with_persistence_options(pparams);
 


### PR DESCRIPTION
This adds a `Blender.recover()` method that goes through and replays the log entries it finds for its base nodes. 

* The log flushes are now separated by a newline, so that each JSON array can be parsed individually.
* `persistence::Parameters` now has an optional `log_prefix` that'll be used to replace `soup` in e.g. `soup-log_0_0-0.json`. Without this parallel tests would sometimes log to the same file - at the same time.
* Packets are re-created from the log entries and passed on to `Domain.handle`. Transactional packets are first passed through `checktable.apply_batch` to retrieve a timestamp. I'm not sure if the latter is completely correct though - cc @fintelia.

I've added a couple of tests, but let me know if there's anything else I should cover.

I also changed the basic example so that it calls `.recover()` and votes with a unique timestamp (so that the count increments each time it's run). Let me know if I should move it to another example or something though.