### PR TITLE
Use rustfmt-nightly 0.2.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - SETTLE_TIME=2000
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - cargo install --git https://github.com/rust-lang-nursery/rustfmt.git --rev 6e41100725267974fa6dcc61134d4377b676ad01 --force
+  - cargo install rustfmt-nightly --vers 0.2.9 --force
 script:
   - cargo fmt -- --write-mode=diff
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - SETTLE_TIME=2000
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - cargo install rustfmt-nightly --vers 0.2.9 --force
+  - cargo install --git https://github.com/rust-lang-nursery/rustfmt.git --rev 9754bcb535fa84c000fe78cb91b30c3f661fc849 --force
 script:
   - cargo fmt -- --write-mode=diff
   - cargo test --verbose


### PR DESCRIPTION
This fixes the Travis build. Was released a week ago, so slightly newer than the hash that was being used before. 