### PR TITLE
Add support for aliases in arithmetic expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
  "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "mysql 11.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=13744adf972e42741b5e7146db46e8ed7353a15d)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4)",
  "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -310,7 +310,7 @@ dependencies = [
  "channel 0.1.0",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=b01998fc34a5d473387987110724a395298fc6c0)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4)",
  "petgraph 0.4.5 (git+https://github.com/fintelia/petgraph?branch=serde)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -364,7 +364,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=b01998fc34a5d473387987110724a395298fc6c0)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4)",
  "petgraph 0.4.5 (git+https://github.com/fintelia/petgraph?branch=serde)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -420,7 +420,7 @@ dependencies = [
  "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "mir 0.1.0",
  "mysql 11.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=b01998fc34a5d473387987110724a395298fc6c0)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.5 (git+https://github.com/fintelia/petgraph?branch=serde)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -883,7 +883,7 @@ version = "0.1.0"
 dependencies = [
  "core 0.1.0",
  "dataflow 0.1.0",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=b01998fc34a5d473387987110724a395298fc6c0)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -998,17 +998,7 @@ dependencies = [
 [[package]]
 name = "nom_sql"
 version = "0.0.1"
-source = "git+https://github.com/ms705/nom-sql.git?rev=13744adf972e42741b5e7146db46e8ed7353a15d#13744adf972e42741b5e7146db46e8ed7353a15d"
-dependencies = [
- "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nom_sql"
-version = "0.0.1"
-source = "git+https://github.com/ms705/nom-sql.git?rev=b01998fc34a5d473387987110724a395298fc6c0#b01998fc34a5d473387987110724a395298fc6c0"
+source = "git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4#fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4"
 dependencies = [
  "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2009,8 +1999,7 @@ dependencies = [
 "checksum nodrop 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c20f62cbc112bb5beabe96e420b34b17cb627edb03039930a37351520efc69ee"
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
-"checksum nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=13744adf972e42741b5e7146db46e8ed7353a15d)" = "<none>"
-"checksum nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=b01998fc34a5d473387987110724a395298fc6c0)" = "<none>"
+"checksum nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4)" = "<none>"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
 "checksum num-complex 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "503e668405c5492d67cf662a81e05be40efe2e6bcf10f7794a07bd9865e704e6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.8", features = ["rc"] }
 # git deps
 petgraph = { git = "https://github.com/fintelia/petgraph", branch = "serde", features = ["serde"] }
 memcached-rs = { git = "https://github.com/jonhoo/memcached-rs.git", branch = "expose-multi" }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "b01998fc34a5d473387987110724a395298fc6c0"}
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4"}
 
 # local deps
 channel = { path = "channel" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -15,7 +15,7 @@ default = ["b_netsoup", "b_memcached", "b_mysql", "b_mssql", "b_hybrid"]
 channel = { path = "../channel" }
 chrono = { version = "0.4.0", features = ["serde"] }
 distributary = { path = ".." }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "13744adf972e42741b5e7146db46e8ed7353a15d"}
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4"}
 regex = "0.2.2"
 slog = "2.0.6"
 #slog = { version = "2.0.6", features = ["max_level_trace", "release_max_level_debug"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.8", features = ["rc"] }
 
 # git deps
 petgraph = { git = "https://github.com/fintelia/petgraph", branch = "serde", features = ["serde"] }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "b01998fc34a5d473387987110724a395298fc6c0"}
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4"}
 vec_map = { version = "0.8.0", features = ["eders"] }
 
 # local deps

--- a/dataflow/Cargo.toml
+++ b/dataflow/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.8", features = ["rc"] }
 timekeeper = {version = "0.3.0", default-features = false }
 # git deps
 petgraph = { git = "https://github.com/fintelia/petgraph", branch = "serde", features = ["serde"] }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "b01998fc34a5d473387987110724a395298fc6c0"}
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4"}
 vec_map = { version = "0.8.0", features = ["eders"] }
 
 # local deps

--- a/mir/Cargo.toml
+++ b/mir/Cargo.toml
@@ -8,7 +8,7 @@ regex = "0.2.2"
 slog = "2.0.6"
 
 # git deps
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "b01998fc34a5d473387987110724a395298fc6c0"}
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fcf7faa4bbb5592b0c1a4991278c0a6cb62926d4"}
 
 # local deps
 core = { path = "../core" }

--- a/src/sql/query_graph.rs
+++ b/src/sql/query_graph.rs
@@ -641,7 +641,7 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
                 }
 
                 qg.columns.push(OutputColumn::Arithmetic(ArithmeticColumn {
-                    name: String::from("arithmetic"),
+                    name: a.alias.clone().unwrap_or(String::from("arithmetic")),
                     table: None,
                     expression: a.clone(),
                 }));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -334,6 +334,49 @@ fn it_works_with_sql_recipe() {
 }
 
 #[test]
+fn it_works_with_arithmetic_aliases() {
+    let mut g = ControllerBuilder::default().build_inner();
+    let sql = "
+        CREATE TABLE Car (cid int, pid int, brand varchar(255), PRIMARY KEY(cid));
+        CREATE TABLE Price (pid int, cent_price int, PRIMARY KEY(pid));
+        CarPrice: SELECT cid, ActualPrice.price FROM Car \
+            JOIN (SELECT pid, cent_price / 100 AS price FROM Price) AS ActualPrice \
+            ON Car.pid = ActualPrice.pid WHERE cid = ?;
+    ";
+
+    let recipe = g.migrate(|mig| {
+        let mut recipe = Recipe::from_str(&sql, None).unwrap();
+        recipe.activate(mig, false).unwrap();
+        recipe
+    });
+
+    let car_index = recipe.node_addr_for("Car").unwrap();
+    let price_index = recipe.node_addr_for("Price").unwrap();
+    let car_price_index = recipe.node_addr_for("CarPrice").unwrap();
+    let mut car_mutator = g.get_mutator(car_index);
+    let mut price_mutator = g.get_mutator(price_index);
+    let mut getter = g.get_getter(car_price_index).unwrap();
+    let cid = 1;
+    let pid = 1;
+    let cent_price = 10000;
+    price_mutator
+        .put(vec![pid.into(), cent_price.into()])
+        .unwrap();
+
+    car_mutator
+        .put(vec![cid.into(), pid.into(), "Volvo".into()])
+        .unwrap();
+
+    // Let writes propagate:
+    sleep();
+
+    // Retrieve the result of the count query:
+    let result = getter.lookup(&cid.into(), true).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0][1], 100.into());
+}
+
+#[test]
 fn it_works_with_simple_arithmetic() {
     let mut g = ControllerBuilder::default().build_inner();
     let sql = "


### PR DESCRIPTION
Not sure if this is the right place to solve this, but it basically sets the column name of the output column to the alias if it exists - or `arithmetic` if it doesn't (I don't think the actual `arithmetic` name is being used for anything?).

This is sort of similar to what's done in [SqlToMirConverter.make_grouped_node](https://github.com/mit-pdos/distributary/blob/master/src/sql/mir.rs#L585-L595). 