### PR TITLE
Use HEAD of rustfmt on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - SETTLE_TIME=2000
 before_script:
   - export PATH="$PATH:$HOME/.cargo/bin"
-  - cargo install --git https://github.com/rust-lang-nursery/rustfmt.git --rev 9754bcb535fa84c000fe78cb91b30c3f661fc849 --force
+  - cargo install --git https://github.com/rust-lang-nursery/rustfmt.git --force
 script:
   - cargo fmt -- --write-mode=diff
   - cargo test --verbose

--- a/src/flow/mutator.rs
+++ b/src/flow/mutator.rs
@@ -259,7 +259,9 @@ impl Mutator {
         }
 
         let pkey = self.key.iter().map(|&col| &u[col]).cloned().collect();
-        Ok(self.send(vec![Record::DeleteRequest(pkey), u.into()].into()))
+        Ok(self.send(
+            vec![Record::DeleteRequest(pkey), u.into()].into(),
+        ))
     }
 
     /// Perform a transactional update (delete followed by put) to the base node this Mutator was

--- a/src/sql/mir.rs
+++ b/src/sql/mir.rs
@@ -865,7 +865,10 @@ impl SqlToMirConverter {
 
                         let last_left = left.last().unwrap().clone();
                         let last_right = right.last().unwrap().clone();
-                        let union = self.make_union_node(&format!("{}_u", name), vec![last_left, last_right]);
+                        let union = self.make_union_node(
+                            &format!("{}_u", name),
+                            vec![last_left, last_right],
+                        );
 
                         pred_nodes.extend(left.clone());
                         pred_nodes.extend(right.clone());

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -579,7 +579,15 @@ impl SqlIncorporator {
                     QueryGraphReuse::ExtendExisting(mqs) => {
                         self.extend_existing_query(&query_name, sq, qg, mqs, mig)
                     }
-                    QueryGraphReuse::ReaderOntoExisting(mn, project_columns, params) => self.add_leaf_to_existing_query(&query_name, &params, mn, project_columns, mig),
+                    QueryGraphReuse::ReaderOntoExisting(mn, project_columns, params) => {
+                        self.add_leaf_to_existing_query(
+                            &query_name,
+                            &params,
+                            mn,
+                            project_columns,
+                            mig,
+                        )
+                    }
                     QueryGraphReuse::None => self.add_query_via_mir(&query_name, sq, qg, mig),
                 }
             }


### PR DESCRIPTION
Seems like pinned rustfmt versions regularly break with new nightly builds, which makes it pretty sub-optimal. This checks the codebase against HEAD of rustfmt instead. That'll probably also break from time to time, but should be easier to fix than having to update the rustfmt revision hash manually.

Another option is to just remove the check altogether - up to you!