### PR TITLE
Use appropriate names for literals and arithmetic expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "channel 0.1.0",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=af113901265d5d9add36ac8f7ff1abee75a220be)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fe7cdaa360c86bd4202e4065bc125ba5642439d2)",
  "petgraph 0.4.5 (git+https://github.com/fintelia/petgraph?branch=serde)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -364,7 +364,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=af113901265d5d9add36ac8f7ff1abee75a220be)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fe7cdaa360c86bd4202e4065bc125ba5642439d2)",
  "petgraph 0.4.5 (git+https://github.com/fintelia/petgraph?branch=serde)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,7 +421,7 @@ dependencies = [
  "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "mir 0.1.0",
  "mysql 11.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=af113901265d5d9add36ac8f7ff1abee75a220be)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fe7cdaa360c86bd4202e4065bc125ba5642439d2)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.5 (git+https://github.com/fintelia/petgraph?branch=serde)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -889,7 +889,7 @@ version = "0.1.0"
 dependencies = [
  "core 0.1.0",
  "dataflow 0.1.0",
- "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=af113901265d5d9add36ac8f7ff1abee75a220be)",
+ "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fe7cdaa360c86bd4202e4065bc125ba5642439d2)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1005,6 +1005,16 @@ dependencies = [
 name = "nom_sql"
 version = "0.0.1"
 source = "git+https://github.com/ms705/nom-sql.git?rev=af113901265d5d9add36ac8f7ff1abee75a220be#af113901265d5d9add36ac8f7ff1abee75a220be"
+dependencies = [
+ "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom_sql"
+version = "0.0.1"
+source = "git+https://github.com/ms705/nom-sql.git?rev=fe7cdaa360c86bd4202e4065bc125ba5642439d2#fe7cdaa360c86bd4202e4065bc125ba5642439d2"
 dependencies = [
  "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2007,6 +2017,7 @@ dependencies = [
 "checksum nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 "checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
 "checksum nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=af113901265d5d9add36ac8f7ff1abee75a220be)" = "<none>"
+"checksum nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=fe7cdaa360c86bd4202e4065bc125ba5642439d2)" = "<none>"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-bigint 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "8fd0f8dbb4c0960998958a796281d88c16fbe68d87b1baa6f31e2979e81fd0bd"
 "checksum num-complex 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "503e668405c5492d67cf662a81e05be40efe2e6bcf10f7794a07bd9865e704e6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.8", features = ["rc"] }
 # git deps
 petgraph = { git = "https://github.com/fintelia/petgraph", branch = "serde", features = ["serde"] }
 memcached-rs = { git = "https://github.com/jonhoo/memcached-rs.git", branch = "expose-multi" }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "af113901265d5d9add36ac8f7ff1abee75a220be" }
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fe7cdaa360c86bd4202e4065bc125ba5642439d2" }
 
 # local deps
 channel = { path = "channel" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.8", features = ["rc"] }
 
 # git deps
 petgraph = { git = "https://github.com/fintelia/petgraph", branch = "serde", features = ["serde"] }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "af113901265d5d9add36ac8f7ff1abee75a220be" }
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fe7cdaa360c86bd4202e4065bc125ba5642439d2" }
 vec_map = { version = "0.8.0", features = ["eders"] }
 
 # local deps

--- a/dataflow/Cargo.toml
+++ b/dataflow/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.8", features = ["rc"] }
 timekeeper = {version = "0.3.0", default-features = false }
 # git deps
 petgraph = { git = "https://github.com/fintelia/petgraph", branch = "serde", features = ["serde"] }
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "af113901265d5d9add36ac8f7ff1abee75a220be" }
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fe7cdaa360c86bd4202e4065bc125ba5642439d2" }
 vec_map = { version = "0.8.0", features = ["eders"] }
 
 # local deps

--- a/dataflow/src/payload.rs
+++ b/dataflow/src/payload.rs
@@ -72,7 +72,9 @@ pub enum ReplayPieceContext {
         for_keys: HashSet<Vec<DataType>>,
         ignore: bool,
     },
-    Regular { last: bool },
+    Regular {
+        last: bool,
+    },
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -161,7 +163,10 @@ pub enum Packet {
     },
 
     /// Drops an existing column from a `Base` node.
-    DropBaseColumn { node: LocalNodeIndex, column: usize },
+    DropBaseColumn {
+        node: LocalNodeIndex,
+        column: usize,
+    },
 
     /// Update Egress node.
     UpdateEgress {
@@ -193,7 +198,9 @@ pub enum Packet {
     },
 
     /// Probe for the number of records in the given node's state
-    StateSizeProbe { node: LocalNodeIndex },
+    StateSizeProbe {
+        node: LocalNodeIndex,
+    },
 
     /// Inform domain about a new replay path.
     SetupReplayPath {
@@ -205,10 +212,16 @@ pub enum Packet {
     },
 
     /// Ask domain (nicely) to replay a particular key.
-    RequestPartialReplay { tag: Tag, key: Vec<DataType> },
+    RequestPartialReplay {
+        tag: Tag,
+        key: Vec<DataType>,
+    },
 
     /// Instruct domain to replay the state of a particular node along an existing replay path.
-    StartReplay { tag: Tag, from: LocalNodeIndex },
+    StartReplay {
+        tag: Tag,
+        from: LocalNodeIndex,
+    },
 
     /// Sent to instruct a domain that a particular node should be considered ready to process
     /// updates.
@@ -233,7 +246,10 @@ pub enum Packet {
     ///
     /// This allows a migration to ensure all transactions happen strictly *before* or *after* a
     /// migration in timestamp order.
-    StartMigration { at: i64, prev_ts: i64 },
+    StartMigration {
+        at: i64,
+        prev_ts: i64,
+    },
 
     /// Notify a domain about a completion timestamp for an ongoing migration.
     ///

--- a/dataflow/src/processing.rs
+++ b/dataflow/src/processing.rs
@@ -30,7 +30,9 @@ pub enum ReplayContext {
         key_col: usize,
         keys: HashSet<Vec<prelude::DataType>>,
     },
-    Full { last: bool },
+    Full {
+        last: bool,
+    },
 }
 
 impl ReplayContext {

--- a/mir/Cargo.toml
+++ b/mir/Cargo.toml
@@ -8,7 +8,7 @@ regex = "0.2.2"
 slog = "2.0.6"
 
 # git deps
-nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "af113901265d5d9add36ac8f7ff1abee75a220be" }
+nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "fe7cdaa360c86bd4202e4065bc125ba5642439d2" }
 
 # local deps
 core = { path = "../core" }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -762,11 +762,9 @@ impl ControllerInner {
         let mut r = Recipe::from_str(&r_txt, Some(self.log.clone())).unwrap();
         let old = self.recipe.clone();
         let mut new = old.replace(r).unwrap();
-        self.migrate(|mig| {
-            match new.activate(mig, false) {
-                Ok(_) => (),
-                Err(e) => panic!("failed to install recipe: {:?}", e),
-            }
+        self.migrate(|mig| match new.activate(mig, false) {
+            Ok(_) => (),
+            Err(e) => panic!("failed to install recipe: {:?}", e),
         });
         self.recipe = new;
     }

--- a/src/controller/sql/mod.rs
+++ b/src/controller/sql/mod.rs
@@ -618,6 +618,8 @@ impl SqlIncorporator {
             // other kinds of queries *do* require their referred tables to exist!
             ref q @ SqlQuery::CompoundSelect(_) |
             ref q @ SqlQuery::Select(_) |
+            ref q @ SqlQuery::Update(_) |
+            ref q @ SqlQuery::Delete(_) |
             ref q @ SqlQuery::Insert(_) => for t in &q.referred_tables() {
                 if !self.view_schemas.contains_key(&t.name) {
                     return Err(format!("query refers to unknown table \"{}\"", t.name));
@@ -1309,7 +1311,7 @@ mod tests {
 
             // leaf view node
             let edge = get_node(&inc, mig, &res.unwrap().name);
-            assert_eq!(edge.fields(), &["name", "literal"]);
+            assert_eq!(edge.fields(), &["name", "1"]);
             assert_eq!(edge.description(), format!("π[1, lit: 1]"));
         });
     }
@@ -1325,13 +1327,20 @@ mod tests {
                     .is_ok()
             );
 
-            let res = inc.add_query("SELECT 2 * users.age FROM users;", None, mig);
+            let res = inc.add_query(
+                "SELECT 2 * users.age, 2 * 10 as twenty FROM users;",
+                None,
+                mig,
+            );
             assert!(res.is_ok());
 
             // leaf view node
             let edge = get_node(&inc, mig, &res.unwrap().name);
-            assert_eq!(edge.fields(), &["arithmetic"]);
-            assert_eq!(edge.description(), format!("π[(lit: 2) * 1]"));
+            assert_eq!(edge.fields(), &["2 * users.age", "twenty"]);
+            assert_eq!(
+                edge.description(),
+                format!("π[(lit: 2) * 1, (lit: 2) * (lit: 10)]")
+            );
         });
     }
 

--- a/src/controller/sql/mod.rs
+++ b/src/controller/sql/mod.rs
@@ -474,7 +474,7 @@ impl SqlIncorporator {
             Some(qg) => {
                 self.query_graphs
                     .insert(qg.signature().hash, (qg, mir.clone()));
-            },
+            }
             None => (),
         }
     }

--- a/src/controller/sql/passes/implied_tables.rs
+++ b/src/controller/sql/passes/implied_tables.rs
@@ -280,6 +280,7 @@ impl ImpliedTableExpansion for SqlQuery {
                     .collect();
                 SqlQuery::Insert(iq)
             }
+            _ => unreachable!(),
         }
     }
 }

--- a/src/controller/sql/query_graph.rs
+++ b/src/controller/sql/query_graph.rs
@@ -626,7 +626,7 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
             }
             FieldExpression::Literal(ref l) => {
                 qg.columns.push(OutputColumn::Literal(LiteralColumn {
-                    name: String::from("literal"),
+                    name: l.to_string(),
                     table: None,
                     value: l.clone(),
                 }));
@@ -641,7 +641,7 @@ pub fn to_query_graph(st: &SelectStatement) -> Result<QueryGraph, String> {
                 }
 
                 qg.columns.push(OutputColumn::Arithmetic(ArithmeticColumn {
-                    name: a.alias.clone().unwrap_or(String::from("arithmetic")),
+                    name: a.alias.clone().unwrap_or(a.to_string()),
                     table: None,
                     expression: a.clone(),
                 }));

--- a/src/controller/sql/query_utils.rs
+++ b/src/controller/sql/query_utils.rs
@@ -17,6 +17,7 @@ impl ReferredTables for SqlQuery {
                     acc
                 },
             ),
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
This uses `.to_string()` on nom-sql's literals and arithmetic expressions for column names. Added a rustfmt commit too for Travis, but I'll remove it if someone runs it on master before this is merged.