### PR TITLE
Re-enable unused warnings, and fix existing instances of them

### DIFF
--- a/src/controller/getter.rs
+++ b/src/controller/getter.rs
@@ -180,6 +180,7 @@ pub struct Getter {
     last_ts: i64,
 }
 
+#[allow(unused)]
 impl Getter {
     pub(crate) fn new(
         node: NodeIndex,

--- a/src/controller/migrate/materialization/mod.rs
+++ b/src/controller/migrate/materialization/mod.rs
@@ -61,6 +61,7 @@ impl Materializations {
         }
     }
 
+    #[allow(unused)]
     pub fn set_logger(&mut self, logger: &Logger) {
         self.log = logger.new(o!());
     }

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -515,6 +515,34 @@ impl ControllerInner {
         listener
     }
 
+    /// Controls the persistence mode, and parameters related to persistence.
+    ///
+    /// Three modes are available:
+    ///
+    ///  1. `DurabilityMode::Permanent`: all writes to base nodes should be written to disk.
+    ///  2. `DurabilityMode::DeleteOnExit`: all writes are written to disk, but the log is
+    ///     deleted once the `Controller` is dropped. Useful for tests.
+    ///  3. `DurabilityMode::MemoryOnly`: no writes to disk, store all writes in memory.
+    ///     Useful for baseline numbers.
+    ///
+    /// `queue_capacity` indicates the number of packets that should be buffered until
+    /// flushing, and `flush_timeout` indicates the length of time to wait before flushing
+    /// anyway.
+    ///
+    /// Must be called before any domains have been created.
+    pub fn with_persistence_options(&mut self, params: PersistenceParameters) {
+        assert_eq!(self.ndomains, 0);
+        self.persistence = params;
+    }
+
+    /// Set the `Logger` to use for internal log messages.
+    ///
+    /// By default, all log messages are discarded.
+    pub fn log_with(&mut self, log: slog::Logger) {
+        self.log = log;
+        self.materializations.set_logger(&self.log);
+    }
+
     /// Perform a new query schema migration.
     pub fn migrate<F, T>(&mut self, f: F) -> T
     where

--- a/src/controller/recipe/mod.rs
+++ b/src/controller/recipe/mod.rs
@@ -62,6 +62,7 @@ fn hash_query(q: &SqlQuery) -> QueryID {
     h.finish()
 }
 
+#[allow(unused)]
 impl Recipe {
     /// Return active aliases for expressions
     pub fn aliases(&self) -> Vec<&str> {

--- a/src/controller/sql/mir.rs
+++ b/src/controller/sql/mir.rs
@@ -7,8 +7,8 @@ pub use mir::FlowNode;
 use dataflow::ops::join::JoinType;
 
 use nom_sql::{ArithmeticExpression, Column, ColumnSpecification, CompoundSelectOperator,
-              CompoundSelectStatement, ConditionBase, ConditionExpression, ConditionTree, Literal,
-              Operator, SqlQuery, TableKey};
+              ConditionBase, ConditionExpression, ConditionTree, Literal, Operator, SqlQuery,
+              TableKey};
 use nom_sql::{LimitClause, OrderClause, SelectStatement};
 use controller::sql::query_graph::{JoinRef, OutputColumn, QueryGraph, QueryGraphEdge};
 use controller::sql::query_signature::Signature;
@@ -22,12 +22,12 @@ fn target_columns_from_computed_column(computed_col: &Column) -> &Column {
     use nom_sql::FunctionExpression::*;
 
     match *computed_col.function.as_ref().unwrap().deref() {
-        Avg(ref col, _) |
-        Count(ref col, _) |
-        GroupConcat(ref col, _) |
-        Max(ref col) |
-        Min(ref col) |
-        Sum(ref col, _) => col,
+        Avg(ref col, _)
+        | Count(ref col, _)
+        | GroupConcat(ref col, _)
+        | Max(ref col)
+        | Min(ref col)
+        | Sum(ref col, _) => col,
         CountStar => {
             // see comment re COUNT(*) rewriting in make_aggregation_node
             panic!("COUNT(*) should have been rewritten earlier!")

--- a/src/controller/sql/mir.rs
+++ b/src/controller/sql/mir.rs
@@ -329,9 +329,9 @@ impl SqlToMirConverter {
         name: &str,
         sq: &SelectStatement,
         qg: &QueryGraph,
-        is_leaf: bool,
+        has_leaf: bool,
     ) -> MirQuery {
-        let nodes = self.make_nodes_for_selection(&name, sq, qg, is_leaf);
+        let nodes = self.make_nodes_for_selection(&name, sq, qg, has_leaf);
         let mut roots = Vec::new();
         let mut leaves = Vec::new();
         for mn in nodes.into_iter() {
@@ -794,6 +794,7 @@ impl SqlToMirConverter {
             vec![fn_col],
             vec![],
             vec![(String::from("grp"), DataType::from(0 as i32))],
+            false,
         )
     }
 
@@ -804,6 +805,7 @@ impl SqlToMirConverter {
         proj_cols: Vec<&Column>,
         arithmetic: Vec<(String, ArithmeticExpression)>,
         literals: Vec<(String, DataType)>,
+        is_leaf: bool,
     ) -> MirNodeRef {
         //assert!(proj_cols.iter().all(|c| c.table == parent_name));
 
@@ -819,11 +821,25 @@ impl SqlToMirConverter {
             .map(|c| match c.alias {
                 Some(ref a) => Column {
                     name: a.clone(),
-                    table: c.table.clone(),
+                    table: if is_leaf {
+                        // if this is the leaf node of a query, it represents a view, so we rewrite
+                        // the table name here.
+                        Some(String::from(name))
+                    } else {
+                        c.table.clone()
+                    },
                     alias: Some(a.clone()),
                     function: c.function.clone(),
                 },
-                None => c.clone(),
+                None => {
+                    let mut c = c.clone();
+                    // if this is the leaf node of a query, it represents a view, so we rewrite the
+                    // table name here.
+                    if is_leaf {
+                        c.table = Some(String::from(name))
+                    }
+                    c
+                }
             })
             .chain(names.into_iter().map(|n| {
                 Column {
@@ -1020,7 +1036,7 @@ impl SqlToMirConverter {
         name: &str,
         st: &SelectStatement,
         qg: &QueryGraph,
-        is_leaf: bool,
+        has_leaf: bool,
     ) -> Vec<MirNodeRef> {
         use std::collections::HashMap;
 
@@ -1434,17 +1450,22 @@ impl SqlToMirConverter {
                 })
                 .collect();
 
-            let ident = format!("q_{:x}_n{}", qg.signature().hash, new_node_count);
-            let leaf_project_node = self.make_project_node(
+            let ident = if has_leaf {
+                format!("q_{:x}_n{}", qg.signature().hash, new_node_count)
+            } else {
+                String::from(name)
+            };
+            let mut leaf_project_node = self.make_project_node(
                 &ident,
                 final_node,
                 projected_columns,
                 projected_arithmetic,
                 projected_literals,
+                !has_leaf,
             );
             nodes_added.push(leaf_project_node.clone());
 
-            if is_leaf {
+            if has_leaf {
                 // We are supposed to add a `MaterializedLeaf` node keyed on the query
                 // parameters. For purely internal views (e.g., subqueries), this is not set.
                 let query_params = qg.parameters();

--- a/src/controller/sql/mir.rs
+++ b/src/controller/sql/mir.rs
@@ -1455,7 +1455,7 @@ impl SqlToMirConverter {
             } else {
                 String::from(name)
             };
-            let mut leaf_project_node = self.make_project_node(
+            let leaf_project_node = self.make_project_node(
                 &ident,
                 final_node,
                 projected_columns,

--- a/src/controller/sql/mod.rs
+++ b/src/controller/sql/mod.rs
@@ -342,15 +342,6 @@ impl SqlIncorporator {
 
         // no optimization, because standalone base nodes can't be optimized
 
-        // TODO(malte): we currently need to remember these for local state, but should figure out
-        // a better plan (see below)
-        let _fields = mir.leaf
-            .borrow()
-            .columns()
-            .into_iter()
-            .map(|c| String::from(c.name.as_str()))
-            .collect::<Vec<_>>();
-
         // push it into the flow graph using the migration in `mig`, and obtain `QueryFlowParts`
         let qfp = mir_query_to_flow_parts(&mut mir, &mut mig);
 

--- a/src/controller/sql/mod.rs
+++ b/src/controller/sql/mod.rs
@@ -81,11 +81,13 @@ impl SqlIncorporator {
     }
 
     /// Disable node reuse for future migrations.
+    #[allow(unused)]
     pub fn disable_reuse(&mut self) {
         self.reuse_type = ReuseConfigType::NoReuse;
     }
 
     /// Disable node reuse for future migrations.
+    #[allow(unused)]
     pub fn enable_reuse(&mut self, reuse_type: ReuseConfigType) {
         self.reuse_type = reuse_type;
     }
@@ -98,6 +100,7 @@ impl SqlIncorporator {
     ///
     /// The return value is a tuple containing the query name (specified or computing) and a `Vec`
     /// of `NodeIndex`es representing the nodes added to support the query.
+    #[allow(unused)]
     pub fn add_query(
         &mut self,
         query: &str,
@@ -133,6 +136,7 @@ impl SqlIncorporator {
     }
 
     /// Retrieves the flow node associated with a given query's leaf view.
+    #[allow(unused)]
     pub fn get_query_address(&self, name: &str) -> Option<NodeIndex> {
         self.mir_converter.get_leaf(name)
     }
@@ -340,7 +344,7 @@ impl SqlIncorporator {
 
         // TODO(malte): we currently need to remember these for local state, but should figure out
         // a better plan (see below)
-        let fields = mir.leaf
+        let _fields = mir.leaf
             .borrow()
             .columns()
             .into_iter()
@@ -394,7 +398,7 @@ impl SqlIncorporator {
         query_name: &str,
         sq: &SelectStatement,
         is_leaf: bool,
-        mut mig: &mut Migration,
+        mig: &mut Migration,
     ) -> (QueryFlowParts, Option<MirQuery>) {
         let (qg, reuse) = self.consider_query_graph(&query_name, sq);
         match reuse {
@@ -557,7 +561,7 @@ impl SqlIncorporator {
         &mut self,
         q: SqlQuery,
         query_name: String,
-        is_leaf: bool,
+        _is_leaf: bool,
         mig: &mut Migration,
     ) -> Result<QueryFlowParts, String> {
         use nom_sql::{JoinRightSide, Table};

--- a/src/controller/sql/mod.rs
+++ b/src/controller/sql/mod.rs
@@ -715,7 +715,6 @@ mod tests {
     use nom_sql::Column;
     use dataflow::prelude::*;
     use controller::{ControllerBuilder, Migration};
-    use Blender;
     use super::{SqlIncorporator, ToFlowParts};
     use nom_sql::FunctionExpression;
 

--- a/src/controller/sql/mod.rs
+++ b/src/controller/sql/mod.rs
@@ -552,7 +552,7 @@ impl SqlIncorporator {
         &mut self,
         q: SqlQuery,
         query_name: String,
-        _is_leaf: bool,
+        is_leaf: bool,
         mig: &mut Migration,
     ) -> Result<QueryFlowParts, String> {
         use nom_sql::{JoinRightSide, Table};
@@ -641,7 +641,7 @@ impl SqlIncorporator {
                 // reused, however.
                 self.add_compound_query(&query_name, csq, mig).unwrap()
             }
-            SqlQuery::Select(ref sq) => self.add_select_query(&query_name, sq, true, mig).0,
+            SqlQuery::Select(ref sq) => self.add_select_query(&query_name, sq, is_leaf, mig).0,
             ref q @ SqlQuery::CreateTable { .. } => self.add_base_via_mir(&query_name, q, mig),
             ref q @ _ => panic!("unhandled query type in recipe: {:?}", q),
         };

--- a/src/controller/sql/passes/implied_tables.rs
+++ b/src/controller/sql/passes/implied_tables.rs
@@ -76,7 +76,6 @@ fn rewrite_selection(
 ) -> SelectStatement {
     use nom_sql::FunctionExpression::*;
     use nom_sql::{GroupByClause, OrderClause};
-    use nom_sql::TableKey::*;
 
     // Tries to find a table with a matching column in the `tables_in_query` (information
     // passed as `write_schemas`; this is not something the parser or the expansion pass can
@@ -224,8 +223,6 @@ fn rewrite_selection(
 
 impl ImpliedTableExpansion for SqlQuery {
     fn expand_implied_tables(self, write_schemas: &HashMap<String, Vec<String>>) -> SqlQuery {
-        use nom_sql::FunctionExpression::*;
-        use nom_sql::{GroupByClause, OrderClause};
         use nom_sql::TableKey::*;
 
         match self {
@@ -236,7 +233,7 @@ impl ImpliedTableExpansion for SqlQuery {
                     .collect();
                 SqlQuery::CompoundSelect(csq)
             }
-            SqlQuery::Select(mut sq) => SqlQuery::Select(rewrite_selection(sq, write_schemas)),
+            SqlQuery::Select(sq) => SqlQuery::Select(rewrite_selection(sq, write_schemas)),
             SqlQuery::CreateTable(mut ctq) => {
                 let table = ctq.table.clone();
                 let transform_key = |key_cols: Vec<Column>| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,7 +312,6 @@
 #![deny(missing_docs)]
 #![feature(plugin, use_extern_macros)]
 #![plugin(tarpc_plugins)]
-#![allow(unused)]
 #![deny(unused_extern_crates)]
 
 extern crate arrayvec;
@@ -331,12 +330,10 @@ extern crate rustful;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate slog;
 extern crate slog_term;
-#[macro_use]
 extern crate tarpc;
 extern crate tokio_core;
 extern crate vec_map;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,33 +1,20 @@
 extern crate glob;
 
-use core::{DataType, Datas};
-use dataflow::DomainBuilder;
-use dataflow::backlog::SingleReadHandle;
-use dataflow::checktable::{Token, TransactionResult};
-use dataflow::debug::{DebugEvent, DebugEventType};
+use core::DataType;
+use dataflow::checktable::Token;
 use dataflow::node::StreamUpdate;
 use dataflow::ops::base::Base;
-use dataflow::ops::filter::{Filter, Operator};
-use dataflow::ops::grouped::aggregate::{Aggregation, Aggregator};
-use dataflow::ops::grouped::concat::{GroupConcat, TextComponent};
-use dataflow::ops::grouped::extremum::{Extremum, ExtremumOperator};
+use dataflow::ops::grouped::aggregate::Aggregation;
 use dataflow::ops::identity::Identity;
 use dataflow::ops::join::{Join, JoinSource, JoinType};
 use dataflow::ops::join::JoinSource::*;
-use dataflow::ops::latest::Latest;
 use dataflow::ops::project::Project;
-use dataflow::ops::topk::TopK;
 use dataflow::ops::union::Union;
-use dataflow::payload::PacketEvent;
 use dataflow::prelude::*;
 use dataflow::{DurabilityMode, PersistenceParameters};
 use controller::ControllerBuilder;
-use coordination::{CoordinationMessage, CoordinationPayload};
-use controller::{Blender, Getter, Migration, Mutator, MutatorBuilder, MutatorError, ReadQuery,
-                 ReadReply, RemoteGetter, RemoteGetterBuilder};
-use controller::recipe::{ActivationResult, Recipe};
-use controller::sql::reuse::ReuseConfigType;
-use controller::sql::{SqlIncorporator, ToFlowParts};
+use controller::recipe::Recipe;
+use controller::sql::SqlIncorporator;
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::thread;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -155,7 +155,7 @@ fn it_works_streaming() {
         emits.insert(b, vec![0, 1]);
         let u = Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
-        let mut cq = mig.stream(c);
+        let cq = mig.stream(c);
         (a, b, cq)
     });
 
@@ -190,11 +190,11 @@ fn shared_interdomain_ancestor() {
 
         let u = Union::new(emits.clone());
         let b = mig.add_ingredient("b", &["a", "b"], u);
-        let mut bq = mig.stream(b);
+        let bq = mig.stream(b);
 
         let u = Union::new(emits);
         let c = mig.add_ingredient("c", &["a", "b"], u);
-        let mut cq = mig.stream(c);
+        let cq = mig.stream(c);
         (a, bq, cq)
     });
 
@@ -294,7 +294,7 @@ fn it_works_deletion() {
         emits.insert(b, vec![1, 2]);
         let u = Union::new(emits);
         let c = mig.add_ingredient("c", &["x", "y"], u);
-        let mut cq = mig.stream(c);
+        let cq = mig.stream(c);
         (a, b, cq)
     });
 
@@ -889,9 +889,9 @@ fn transactional_vote() {
 
     let token = articleq.transactional_lookup(&a1).unwrap().1;
 
-    let mut endq_token = endq.transactional_lookup(&a2).unwrap().1;
-    let mut endq_title_token = endq_title.transactional_lookup(&4.into()).unwrap().1;
-    let mut endq_votes_token = endq_votes.transactional_lookup(&0.into()).unwrap().1;
+    let endq_token = endq.transactional_lookup(&a2).unwrap().1;
+    let endq_title_token = endq_title.transactional_lookup(&4.into()).unwrap().1;
+    let endq_votes_token = endq_votes.transactional_lookup(&0.into()).unwrap().1;
 
     // make one article
     assert!(
@@ -935,9 +935,9 @@ fn transactional_vote() {
     token.merge(token2);
     assert!(validate(&token));
 
-    let mut endq_token = endq.transactional_lookup(&a1).unwrap().1;
-    let mut endq_title_token = endq_title.transactional_lookup(&4.into()).unwrap().1;
-    let mut endq_votes_token = endq_votes.transactional_lookup(&0.into()).unwrap().1;
+    let endq_token = endq.transactional_lookup(&a1).unwrap().1;
+    let endq_title_token = endq_title.transactional_lookup(&4.into()).unwrap().1;
+    let endq_votes_token = endq_votes.transactional_lookup(&0.into()).unwrap().1;
 
     // create a vote (user 1 votes for article 1)
     assert!(
@@ -1071,7 +1071,7 @@ fn add_columns() {
     let mut g = ControllerBuilder::default().build_inner();
     let (a, aq) = g.migrate(|mig| {
         let a = mig.add_ingredient("a", &["a", "b"], Base::new(vec![1.into(), 2.into()]));
-        let mut aq = mig.stream(a);
+        let aq = mig.stream(a);
         (a, aq)
     });
     let mut muta = g.get_mutator(a);
@@ -1505,7 +1505,7 @@ fn crossing_migration() {
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
 
-    let mut cq = g.migrate(|mig| {
+    let cq = g.migrate(|mig| {
         let mut emits = HashMap::new();
         emits.insert(a, vec![0, 1]);
         emits.insert(b, vec![0, 1]);
@@ -1587,7 +1587,7 @@ fn domain_amend_migration() {
     let mut muta = g.get_mutator(a);
     let mut mutb = g.get_mutator(b);
 
-    let mut cq = g.migrate(|mig| {
+    let cq = g.migrate(|mig| {
         let mut emits = HashMap::new();
         emits.insert(a, vec![0, 1]);
         emits.insert(b, vec![0, 1]);

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -128,7 +128,9 @@ impl Worker {
             RpcPollingLoop::new(SocketAddr::new(listen_addr.parse().unwrap(), 0));
         let read_listen_addr = read_polling_loop.get_listener_addr().unwrap();
         let builder = thread::Builder::new().name("wrkr-reads".to_owned());
-        builder.spawn(move || Self::serve_reads(read_polling_loop, readers_clone));
+        builder
+            .spawn(move || Self::serve_reads(read_polling_loop, readers_clone))
+            .unwrap();
         println!("Listening for reads on {:?}", read_listen_addr);
 
         Worker {


### PR DESCRIPTION
A lot of these changes are in SQL/MIR which I'm not too familiar with, so I didn't want to push to master without confirmation. For the most part I just tagged functions/structs with `#[allow(unused)]` but it may be the case that many of them should be remove instead. 