### PR TITLE
Implement From<usize> for DataType

### DIFF
--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -122,6 +122,12 @@ impl From<i32> for DataType {
     }
 }
 
+impl From<usize> for DataType {
+    fn from(s: usize) -> Self {
+        DataType::Int(s as i32)
+    }
+}
+
 impl From<f64> for DataType {
     fn from(f: f64) -> Self {
         if !f.is_finite() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -343,8 +343,7 @@ fn it_works_with_sql_recipe() {
     let mut getter = g.get_getter(count_index).unwrap();
     let brands = vec!["Volvo", "Volvo", "Volkswagen"];
     for (i, &brand) in brands.iter().enumerate() {
-        let id = i as i32;
-        mutator.put(vec![id.into(), brand.into()]).unwrap();
+        mutator.put(vec![i.into(), brand.into()]).unwrap();
     }
 
     // Let writes propagate:
@@ -543,7 +542,7 @@ fn it_recovers_persisted_logs_w_multiple_nodes() {
         let (g, recipe) = setup();
         for (i, table) in tables.iter().enumerate() {
             let mut mutator = g.get_mutator(recipe.node_addr_for(table).unwrap());
-            mutator.put(vec![(i as i32).into()]).unwrap();
+            mutator.put(vec![i.into()]).unwrap();
         }
 
         // Let writes propagate:
@@ -556,12 +555,11 @@ fn it_recovers_persisted_logs_w_multiple_nodes() {
     sleep();
 
     for (i, table) in tables.iter().enumerate() {
-        let id = i as i32;
         let mut getter = g.get_getter(recipe.node_addr_for(&format!("{}ID", table)).unwrap())
             .unwrap();
-        let result = getter.lookup(&id.into(), true).unwrap();
+        let result = getter.lookup(&i.into(), true).unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0][0], id.into());
+        assert_eq!(result[0][0], i.into());
     }
 }
 
@@ -750,7 +748,7 @@ fn it_works_with_function_arithmetic() {
     let mut getter = g.get_getter(query_index).unwrap();
     let max_price = 20;
     for (i, price) in (10..max_price + 1).enumerate() {
-        let id = (i + 1) as i32;
+        let id = i + 1;
         mutator.put(vec![id.into(), price.into()]).unwrap();
     }
 


### PR DESCRIPTION
Just thought it was annoying having to do `(i as i32).into()` in tests etc. - feel free to close if there's a good reason why it isn't implemented though!