### PR TITLE
Explicitly tag public queries in recipes

### DIFF
--- a/benchmarks/vote/graph.rs
+++ b/benchmarks/vote/graph.rs
@@ -88,7 +88,7 @@ pub fn make(s: Setup, persistence_params: PersistenceParameters) -> Graph {
                CREATE TABLE Vote (id int, user int, PRIMARY KEY(id));
 
                # read queries
-               ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
+               QUERY ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
                             FROM Article \
                             JOIN (SELECT Vote.id, COUNT(user) AS votes \
                                   FROM Vote GROUP BY Vote.id) AS VoteCount \
@@ -122,13 +122,13 @@ impl Graph {
                CREATE TABLE Rating (id int, user int, stars int, PRIMARY KEY(id));
 
                # read queries
-               ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
+               QUERY ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
                             FROM Article \
                             JOIN (SELECT Vote.id, COUNT(user) AS votes \
                                   FROM Vote GROUP BY Vote.id) AS VoteCount \
                             ON (Article.id = VoteCount.id) WHERE Article.id = ?;
                U: SELECT id, stars FROM Rating UNION SELECT id, 1 FROM Vote;
-               ArticleWithScore: SELECT Article.id, title, Total.score AS score \
+               QUERY ArticleWithScore: SELECT Article.id, title, Total.score AS score \
                             FROM Article \
                             JOIN (SELECT id, SUM(stars) AS score \
                                   FROM U \
@@ -142,7 +142,7 @@ impl Graph {
                CREATE TABLE Rating (id int, user int, stars int, PRIMARY KEY(id));
 
                # read queries
-               ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
+               QUERY ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
                             FROM Article \
                             JOIN (SELECT Vote.id, COUNT(user) AS votes \
                                   FROM Vote GROUP BY Vote.id) AS VoteCount \
@@ -150,7 +150,7 @@ impl Graph {
 
                RatingSum: SELECT id, SUM(stars) AS score FROM Rating GROUP BY id;
                U: SELECT id, score FROM RatingSum UNION SELECT id, votes FROM VoteCount;
-               ArticleWithScore: SELECT Article.id, title, SUM(U.score) AS score \
+               QUERY ArticleWithScore: SELECT Article.id, title, SUM(U.score) AS score \
                             FROM Article, U \
                             WHERE Article.id = U.id AND Article.id = ? \
                             GROUP BY Article.id;";

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -15,7 +15,8 @@ fn main() {
                # read queries
                VoteCount: SELECT Vote.aid, COUNT(uid) AS votes \
                             FROM Vote GROUP BY Vote.aid;
-               ArticleWithVoteCount: SELECT Article.aid, title, url, VoteCount.votes AS votes \
+               QUERY ArticleWithVoteCount: \
+                            SELECT Article.aid, title, url, VoteCount.votes AS votes \
                             FROM Article, VoteCount \
                             WHERE Article.aid = VoteCount.aid AND Article.aid = ?;";
 

--- a/src/controller/recipe/mod.rs
+++ b/src/controller/recipe/mod.rs
@@ -27,7 +27,7 @@ pub struct ActivationResult {
 #[derive(Clone, Debug)]
 pub struct Recipe {
     /// SQL queries represented in the recipe. Value tuple is (name, query).
-    expressions: HashMap<QueryID, (Option<String>, SqlQuery)>,
+    expressions: HashMap<QueryID, (Option<String>, SqlQuery, bool)>,
     /// Addition order for the recipe expressions
     expression_order: Vec<QueryID>,
     /// Named read/write expression aliases, mapping to queries in `expressions`.
@@ -115,7 +115,7 @@ impl Recipe {
                 let na = match self.aliases.get(name) {
                     None => inc.get_query_address(name),
                     Some(ref qid) => {
-                        let (ref internal_qn, _) = self.expressions[qid];
+                        let (ref internal_qn, _, _) = self.expressions[qid];
                         inc.get_query_address(internal_qn.as_ref().unwrap())
                     }
                 };
@@ -155,12 +155,15 @@ impl Recipe {
     /// Creates a recipe from a set of pre-parsed `SqlQuery` structures.
     /// Note that the recipe is not backed by a Soup data-flow graph until `activate` is called on
     /// it.
-    pub fn from_queries(qs: Vec<(Option<String>, SqlQuery)>, log: Option<slog::Logger>) -> Recipe {
+    pub fn from_queries(
+        qs: Vec<(Option<String>, SqlQuery, bool)>,
+        log: Option<slog::Logger>,
+    ) -> Recipe {
         let mut aliases = HashMap::default();
         let mut expression_order = Vec::new();
         let mut duplicates = 0;
         let expressions = qs.into_iter()
-            .map(|(n, q)| {
+            .map(|(n, q, is_leaf)| {
                 let qid = hash_query(&q);
                 if !expression_order.contains(&qid) {
                     expression_order.push(qid);
@@ -173,9 +176,9 @@ impl Recipe {
                         aliases.insert(name.clone(), qid);
                     }
                 }
-                (qid.into(), (n, q))
+                (qid.into(), (n, q, is_leaf))
             })
-            .collect::<HashMap<QueryID, (Option<String>, SqlQuery)>>();
+            .collect::<HashMap<QueryID, (Option<String>, SqlQuery, bool)>>();
 
         let inc = match log {
             None => SqlIncorporator::default(),
@@ -242,13 +245,13 @@ impl Recipe {
         // incorporator in `inc`. `NodeIndex`es for new nodes are collected in `new_nodes` to be
         // returned to the caller (who may use them to obtain mutators and getters)
         for qid in added {
-            let (n, q) = self.expressions[&qid].clone();
+            let (n, q, is_leaf) = self.expressions[&qid].clone();
 
             // add the query
             let qfp = self.inc
                 .as_mut()
                 .unwrap()
-                .add_parsed_query(q, n.clone(), true, mig)?;
+                .add_parsed_query(q, n.clone(), is_leaf, mig)?;
 
             // we currently use a domain per query
             // let d = mig.add_domain();
@@ -300,7 +303,7 @@ impl Recipe {
     pub fn expressions(&self) -> Vec<(Option<&String>, &SqlQuery)> {
         self.expressions
             .values()
-            .map(|&(ref n, ref q)| (n.as_ref(), q))
+            .map(|&(ref n, ref q, _)| (n.as_ref(), q))
             .collect()
     }
 
@@ -341,7 +344,7 @@ impl Recipe {
         Ok(new)
     }
 
-    fn parse(recipe_text: &str) -> Result<Vec<(Option<String>, SqlQuery)>, String> {
+    fn parse(recipe_text: &str) -> Result<Vec<(Option<String>, SqlQuery, bool)>, String> {
         let lines: Vec<&str> = recipe_text
             .lines()
             .filter(|l| !l.is_empty() && !l.starts_with("#"))
@@ -374,12 +377,16 @@ impl Recipe {
                 if r.len() == 2 {
                     // named query
                     let q = r[1];
-                    let name = Some(String::from(r[0]));
-                    (name, q.clone(), sql_parser::parse_query(q))
+                    let (is_leaf, name) = if r[0].starts_with("QUERY ") {
+                        (true, Some(String::from(&r[0][6..])))
+                    } else {
+                        (false, Some(String::from(r[0])))
+                    };
+                    (name, q.clone(), sql_parser::parse_query(q), is_leaf)
                 } else {
                     // unnamed query
                     let q = r[0];
-                    (None, q.clone(), sql_parser::parse_query(q))
+                    (None, q.clone(), sql_parser::parse_query(q), false)
                 }
             })
             .collect::<Vec<_>>();
@@ -397,7 +404,7 @@ impl Recipe {
         Ok(
             parsed_queries
                 .into_iter()
-                .map(|t| (t.0, t.2.unwrap()))
+                .map(|t| (t.0, t.2.unwrap(), t.3))
                 .collect::<Vec<_>>(),
         )
     }
@@ -444,7 +451,7 @@ mod tests {
         let q0_id = hash_query(&q0);
         let q1_id = hash_query(&q1);
 
-        let pq_a = vec![(None, q0.clone()), (None, q1.clone())];
+        let pq_a = vec![(None, q0.clone(), true), (None, q1.clone(), true)];
         let r1 = Recipe::from_queries(pq_a, None);
 
         // delta from empty recipe
@@ -462,7 +469,7 @@ mod tests {
         // bring on a new query set
         let q2 = sql_parser::parse_query("SELECT c FROM b;").unwrap();
         let q2_id = hash_query(&q2);
-        let pq_b = vec![(None, q0), (None, q2.clone())];
+        let pq_b = vec![(None, q0, true), (None, q2.clone(), true)];
         let r2 = Recipe::from_queries(pq_b, None);
 
         // delta should show addition and removal

--- a/src/controller/recipe/mod.rs
+++ b/src/controller/recipe/mod.rs
@@ -377,7 +377,7 @@ impl Recipe {
                 if r.len() == 2 {
                     // named query
                     let q = r[1];
-                    let (is_leaf, name) = if r[0].starts_with("QUERY ") {
+                    let (is_leaf, name) = if r[0].to_lowercase().starts_with("query ") {
                         (true, Some(String::from(&r[0][6..])))
                     } else {
                         (false, Some(String::from(r[0])))

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -327,7 +327,7 @@ fn it_works_with_sql_recipe() {
     let mut g = ControllerBuilder::default().build_inner();
     let sql = "
         CREATE TABLE Car (id int, brand varchar(255), PRIMARY KEY(id));
-        CountCars: SELECT COUNT(*) FROM Car WHERE brand = ?;
+        QUERY CountCars: SELECT COUNT(*) FROM Car WHERE brand = ?;
     ";
 
     let recipe = g.migrate(|mig| {
@@ -361,7 +361,7 @@ fn it_works_with_arithmetic_aliases() {
     let sql = "
         CREATE TABLE Car (cid int, pid int, brand varchar(255), PRIMARY KEY(cid));
         CREATE TABLE Price (pid int, cent_price int, PRIMARY KEY(pid));
-        CarPrice: SELECT cid, ActualPrice.price FROM Car \
+        QUERY CarPrice: SELECT cid, ActualPrice.price FROM Car \
             JOIN (SELECT pid, cent_price / 100 AS price FROM Price) AS ActualPrice \
             ON Car.pid = ActualPrice.pid WHERE cid = ?;
     ";
@@ -413,7 +413,7 @@ fn it_recovers_persisted_logs() {
 
         let sql = "
             CREATE TABLE Car (id int, price int, PRIMARY KEY(id));
-            CarPrice: SELECT price FROM Car WHERE id = ?;
+            QUERY CarPrice: SELECT price FROM Car WHERE id = ?;
         ";
 
         let recipe = g.migrate(|mig| {
@@ -523,9 +523,9 @@ fn it_recovers_persisted_logs_w_multiple_nodes() {
             CREATE TABLE B (id int, PRIMARY KEY(id));
             CREATE TABLE C (id int, PRIMARY KEY(id));
 
-            AID: SELECT id FROM A WHERE id = ?;
-            BID: SELECT id FROM B WHERE id = ?;
-            CID: SELECT id FROM C WHERE id = ?;
+            QUERY AID: SELECT id FROM A WHERE id = ?;
+            QUERY BID: SELECT id FROM B WHERE id = ?;
+            QUERY CID: SELECT id FROM C WHERE id = ?;
         ";
 
 
@@ -625,7 +625,7 @@ fn it_works_with_simple_arithmetic() {
     let mut g = ControllerBuilder::default().build_inner();
     let sql = "
         CREATE TABLE Car (id int, price int, PRIMARY KEY(id));
-        CarPrice: SELECT 2 * price FROM Car WHERE id = ?;
+        QUERY CarPrice: SELECT 2 * price FROM Car WHERE id = ?;
     ";
 
     let recipe = g.migrate(|mig| {
@@ -656,7 +656,7 @@ fn it_works_with_multiple_arithmetic_expressions() {
     let mut g = ControllerBuilder::default().build_inner();
     let sql = "
         CREATE TABLE Car (id int, price int, PRIMARY KEY(id));
-        CarPrice: SELECT 10 * 10, 2 * price, 10 * price, FROM Car WHERE id = ?;
+        QUERY CarPrice: SELECT 10 * 10, 2 * price, 10 * price, FROM Car WHERE id = ?;
     ";
 
     let recipe = g.migrate(|mig| {
@@ -691,7 +691,7 @@ fn it_works_with_join_arithmetic() {
         CREATE TABLE Car (car_id int, price_id int, PRIMARY KEY(car_id));
         CREATE TABLE Price (price_id int, price int, PRIMARY KEY(price_id));
         CREATE TABLE Sales (sales_id int, price_id int, fraction float, PRIMARY KEY(sales_id));
-        CarPrice: SELECT price * fraction FROM Car \
+        QUERY CarPrice: SELECT price * fraction FROM Car \
                   JOIN Price ON Car.price_id = Price.price_id \
                   JOIN Sales ON Price.price_id = Sales.price_id \
                   WHERE car_id = ?;
@@ -734,7 +734,7 @@ fn it_works_with_function_arithmetic() {
     let mut g = ControllerBuilder::default().build_inner();
     let sql = "
         CREATE TABLE Bread (id int, price int, PRIMARY KEY(id));
-        Price: SELECT 2 * MAX(price) FROM Bread;
+        QUERY Price: SELECT 2 * MAX(price) FROM Bread;
     ";
 
     let recipe = g.migrate(|mig| {
@@ -2051,8 +2051,8 @@ fn recipe_activates_and_migrates() {
 
     let r_copy = r.clone();
 
-    let r1_txt = "SELECT a FROM b;\n
-                  SELECT a, c FROM b WHERE a = 42;";
+    let r1_txt = "QUERY qa: SELECT a FROM b;\n
+                  QUERY qb: SELECT a, c FROM b WHERE a = 42;";
     let mut r1 = r.extend(r1_txt).unwrap();
     assert_eq!(r1.version(), 1);
     assert_eq!(r1.expressions().len(), 3);
@@ -2084,7 +2084,7 @@ fn recipe_activates_and_migrates_with_join() {
 
     let r_copy = r.clone();
 
-    let r1_txt = "SELECT y, s FROM a, b WHERE a.x = b.r;";
+    let r1_txt = "QUERY q: SELECT y, s FROM a, b WHERE a.x = b.r;";
     let mut r1 = r.extend(r1_txt).unwrap();
     assert_eq!(r1.version(), 1);
     assert_eq!(r1.expressions().len(), 3);


### PR DESCRIPTION
This changes the recipe syntax to allow two forms of named query:

 1. `QUERY q_name: SELECT ...`
 2. `q_name: SELECT ...`

The first is a *public* query, i.e., one that a client wishes to read from and for which we must maintain a leaf materialization. The second is a *shorthand*, nested query that clients won't query, but which other queries might refer to (treating it as a view/table). Only public queries receive readable leaf materializations (= reader nodes in the data flow).

Note that this is a breaking change that breaks all existing recipes. I've fixed the unit tests, the example, and "vote"; other branches need to take care when merging (@larat7 @fintelia @jonhoo @ekmartin)