### PR TITLE
Materialization status in graphviz

### DIFF
--- a/dataflow/src/node/debug.rs
+++ b/dataflow/src/node/debug.rs
@@ -17,7 +17,11 @@ impl fmt::Debug for Node {
 }
 
 impl Node {
-    pub fn describe(&self, idx: NodeIndex) -> String {
+    pub fn describe(
+        &self,
+        idx: NodeIndex,
+        materialization_status: Option<MaterializationStatus>,
+    ) -> String {
         let mut s = String::new();
         let border = match self.sharded_by {
             Sharding::ByColumn(_, _) | Sharding::Random(_) => "filled,dashed",
@@ -32,6 +36,12 @@ impl Node {
                 .unwrap_or("white".into())
         ));
 
+        let materialized = match materialization_status {
+            None => "",
+            Some(MaterializationStatus::Partial) => "| ◑",
+            Some(MaterializationStatus::Full) => "| ⬤",
+        };
+
         let addr = match self.index {
             Some(ref idx) => if idx.has_local() {
                 format!("{} / {}", idx.as_global().index(), **idx)
@@ -40,10 +50,15 @@ impl Node {
             },
             None => format!("{} / -", idx.index()),
         };
+
         match self.inner {
             NodeType::Source => s.push_str("(source)"),
             NodeType::Dropped => s.push_str("✗"),
-            NodeType::Ingress => s.push_str(&format!("{{ {} | (ingress) }}", addr)),
+            NodeType::Ingress => s.push_str(&format!(
+                "{{ {{ {} {} }} | (ingress) }}",
+                addr,
+                materialized
+            )),
             NodeType::Egress { .. } => s.push_str(&format!("{{ {} | (egress) }}", addr)),
             NodeType::Sharder { .. } => s.push_str(&format!("{{ {} | (sharder) }}", addr)),
             NodeType::Reader(ref r) => {
@@ -52,10 +67,11 @@ impl Node {
                     Some(k) => format!("{}", k),
                 };
                 s.push_str(&format!(
-                    "{{ {} / {} | (reader / ⚷: {}) }}",
+                    "{{ {{ {} / {} {} }} | (reader / ⚷: {}) }}",
                     addr,
                     Self::escape(self.name()),
-                    key
+                    materialized,
+                    key,
                 ))
             }
             NodeType::Internal(ref i) => {
@@ -63,10 +79,11 @@ impl Node {
 
                 // Output node name and description. First row.
                 s.push_str(&format!(
-                    "{{ {} / {} | {} }}",
+                    "{{ {} / {} | {} {} }}",
                     addr,
                     Self::escape(self.name()),
-                    Self::escape(&i.description())
+                    Self::escape(&i.description()),
+                    materialized
                 ));
 
                 // Output node outputs. Second row.

--- a/dataflow/src/node/debug.rs
+++ b/dataflow/src/node/debug.rs
@@ -38,8 +38,8 @@ impl Node {
 
         let materialized = match materialization_status {
             MaterializationStatus::Not => "",
-            MaterializationStatus::Partial => "| ◑",
-            MaterializationStatus::Full => "| ⬤",
+            MaterializationStatus::Partial => "| ▓",
+            MaterializationStatus::Full => "| █",
         };
 
         let addr = match self.index {

--- a/dataflow/src/node/debug.rs
+++ b/dataflow/src/node/debug.rs
@@ -20,7 +20,7 @@ impl Node {
     pub fn describe(
         &self,
         idx: NodeIndex,
-        materialization_status: Option<MaterializationStatus>,
+        materialization_status: MaterializationStatus,
     ) -> String {
         let mut s = String::new();
         let border = match self.sharded_by {
@@ -37,9 +37,9 @@ impl Node {
         ));
 
         let materialized = match materialization_status {
-            None => "",
-            Some(MaterializationStatus::Partial) => "| ◑",
-            Some(MaterializationStatus::Full) => "| ⬤",
+            MaterializationStatus::Not => "",
+            MaterializationStatus::Partial => "| ◑",
+            MaterializationStatus::Full => "| ⬤",
         };
 
         let addr = match self.index {

--- a/dataflow/src/node/mod.rs
+++ b/dataflow/src/node/mod.rs
@@ -16,6 +16,12 @@ pub use self::ntype::NodeType;
 
 mod debug;
 
+#[derive(Debug)]
+pub enum MaterializationStatus {
+    Full,
+    Partial,
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Node {
     name: String,

--- a/dataflow/src/node/mod.rs
+++ b/dataflow/src/node/mod.rs
@@ -18,6 +18,7 @@ mod debug;
 
 #[derive(Debug)]
 pub enum MaterializationStatus {
+    Not,
     Full,
     Partial,
 }

--- a/dataflow/src/prelude.rs
+++ b/dataflow/src/prelude.rs
@@ -7,7 +7,7 @@ pub use processing::{Ingredient, Miss, ProcessingResult, RawProcessingResult, Re
 pub use ops::NodeOperator;
 
 // graph types
-pub use node::Node;
+pub use node::{MaterializationStatus, Node};
 pub type Edge = ();
 pub type Graph = petgraph::Graph<Node, Edge>;
 

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -34,6 +34,8 @@ fn main() {
 
     let mut blender = builder.build();
     blender.install_recipe(sql.to_owned());
+    println!("{}", blender.graphviz());
+
     blender.recover();
     thread::sleep(Duration::from_millis(1000));
 

--- a/src/controller/migrate/materialization/mod.rs
+++ b/src/controller/migrate/materialization/mod.rs
@@ -404,6 +404,21 @@ impl Materializations {
         assert!(replay_obligations.is_empty());
     }
 
+    /// Retrieves the materialization status of a given node, or None
+    /// if the node isn't materialized.
+    pub fn get_status(&self, index: &NodeIndex, node: &Node) -> Option<MaterializationStatus> {
+        let is_materialized = self.have.contains_key(index)
+            || node.with_reader(|r| r.is_materialized()).unwrap_or(false);
+
+        if !is_materialized {
+            None
+        } else if self.partial.contains(index) {
+            Some(MaterializationStatus::Partial)
+        } else {
+            Some(MaterializationStatus::Full)
+        }
+    }
+
     /// Commit to all materialization decisions since the last time `commit` was called.
     ///
     /// This includes setting up replay paths, adding new indices to existing materializations, and

--- a/src/controller/migrate/materialization/mod.rs
+++ b/src/controller/migrate/materialization/mod.rs
@@ -406,16 +406,16 @@ impl Materializations {
 
     /// Retrieves the materialization status of a given node, or None
     /// if the node isn't materialized.
-    pub fn get_status(&self, index: &NodeIndex, node: &Node) -> Option<MaterializationStatus> {
+    pub fn get_status(&self, index: &NodeIndex, node: &Node) -> MaterializationStatus {
         let is_materialized = self.have.contains_key(index)
             || node.with_reader(|r| r.is_materialized()).unwrap_or(false);
 
         if !is_materialized {
-            None
+            MaterializationStatus::Not
         } else if self.partial.contains(index) {
-            Some(MaterializationStatus::Partial)
+            MaterializationStatus::Partial
         } else {
-            Some(MaterializationStatus::Full)
+            MaterializationStatus::Full
         }
     }
 

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -808,9 +808,11 @@ impl ControllerInner {
 
         // node descriptions.
         for index in self.ingredients.node_indices() {
+            let node = &self.ingredients[index];
+            let materialization_status = self.materializations.get_status(&index, node);
             indentln(&mut s);
             s.push_str(&format!("{}", index.index()));
-            s.push_str(&self.ingredients[index].describe(index));
+            s.push_str(&node.describe(index, materialization_status));
         }
 
         // edges.


### PR DESCRIPTION
The snapshotting implementation needs to know which domains have at least one materialized node, but I thought it might be useful to show it in Blender's graphviz output as well.

I'm not sure if the way I'm retrieving materialization status for a node is correct, so let me know if there's a better way to achieve the same. 

This is what it outputs for the example:
![image](https://user-images.githubusercontent.com/3536982/33572549-8b9a8036-d933-11e7-84b6-0fdcf7cc71a3.png)

Feel free to bikeshed on how it should be shown in the output - currently it uses a half circle  for partial and a full circle for full materializations.