### PR TITLE
Remove window support from TCP channels

### DIFF
--- a/channel/src/lib.rs
+++ b/channel/src/lib.rs
@@ -1,5 +1,6 @@
-#![feature(custom_attribute)]
 #![feature(bufreader_is_empty)]
+#![feature(custom_attribute)]
+#![feature(try_from)]
 #![deny(unused_extern_crates)]
 
 extern crate bincode;

--- a/channel/src/tcp.rs
+++ b/channel/src/tcp.rs
@@ -52,7 +52,8 @@ pub struct TcpSender<T> {
 }
 
 impl<T: Serialize> TcpSender<T> {
-    pub fn new(mut stream: std::net::TcpStream, window: Option<u32>) -> Result<Self, io::Error> {
+    pub fn new(mut stream: std::net::TcpStream) -> Result<Self, io::Error> {
+        let window = None;
         if let Some(window) = window {
             assert!(window > 0);
         }
@@ -68,8 +69,8 @@ impl<T: Serialize> TcpSender<T> {
         })
     }
 
-    pub fn connect(addr: &SocketAddr, window: Option<u32>) -> Result<Self, io::Error> {
-        Self::new(std::net::TcpStream::connect(addr)?, window)
+    pub fn connect(addr: &SocketAddr) -> Result<Self, io::Error> {
+        Self::new(std::net::TcpStream::connect(addr)?)
     }
 
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
@@ -321,20 +322,7 @@ where
     for<'de> T: Deserialize<'de>,
 {
     let (tx, rx) = connect(listen_addr);
-    let tx = TcpSender::new(tx, None).unwrap();
-    let rx = TcpReceiver::new(rx);
-    (tx, rx)
-}
-
-pub fn sync_channel<T: Serialize>(
-    listen_addr: SocketAddr,
-    size: u32,
-) -> (TcpSender<T>, TcpReceiver<T>)
-where
-    for<'de> T: Deserialize<'de>,
-{
-    let (tx, rx) = connect(listen_addr);
-    let tx = TcpSender::new(tx, Some(size)).unwrap();
+    let tx = TcpSender::new(tx).unwrap();
     let rx = TcpReceiver::new(rx);
     (tx, rx)
 }

--- a/channel/src/tcp.rs
+++ b/channel/src/tcp.rs
@@ -1,11 +1,12 @@
 use std;
-use std::io::{self, BufReader, Read, Write};
+use std::convert::TryFrom;
+use std::io::{self, BufReader, Write};
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 
 use bincode::{self, Infinite};
 use bufstream::BufStream;
-use byteorder::{ByteOrder, NetworkEndian, WriteBytesExt};
+use byteorder::{NetworkEndian, WriteBytesExt};
 use mio::{self, Evented, Poll, PollOpt, Ready, Token};
 use serde::{Deserialize, Serialize};
 
@@ -44,26 +45,15 @@ macro_rules! poisoning_try {
 
 pub struct TcpSender<T> {
     stream: BufStream<std::net::TcpStream>,
-    window: Option<u32>,
-    unacked: u32,
     poisoned: bool,
 
     phantom: PhantomData<T>,
 }
 
 impl<T: Serialize> TcpSender<T> {
-    pub fn new(mut stream: std::net::TcpStream) -> Result<Self, io::Error> {
-        let window = None;
-        if let Some(window) = window {
-            assert!(window > 0);
-        }
-
-        stream.write_u32::<NetworkEndian>(window.unwrap_or(0))?;
-
+    pub fn new(stream: std::net::TcpStream) -> Result<Self, io::Error> {
         Ok(Self {
             stream: BufStream::new(stream),
-            window,
-            unacked: 0,
             poisoned: false,
             phantom: PhantomData,
         })
@@ -92,16 +82,7 @@ impl<T: Serialize> TcpSender<T> {
             return Err(SendError::Poisoned);
         }
 
-        if let Some(window) = self.window {
-            if self.unacked == window {
-                let mut buf = [0u8];
-                poisoning_try!(self, self.stream.read_exact(&mut buf));
-                self.unacked = 0;
-            }
-            self.unacked += 1;
-        }
-
-        let size: u32 = bincode::serialized_size(t) as u32;
+        let size = u32::try_from(bincode::serialized_size(t)).unwrap();
         poisoning_try!(self, self.stream.write_u32::<NetworkEndian>(size));
         poisoning_try!(self, bincode::serialize_into(&mut self.stream, t, Infinite));
         poisoning_try!(self, self.stream.flush());
@@ -122,44 +103,9 @@ pub enum RecvError {
     DeserializationError(bincode::Error),
 }
 
-#[derive(Default)]
-struct Buffer {
-    data: Vec<u8>,
-    size: usize,
-}
-
-impl Buffer {
-    pub fn fill_from<T: Read>(
-        &mut self,
-        stream: &mut T,
-        target_size: usize,
-    ) -> Result<(), io::Error> {
-        if self.data.len() < target_size {
-            self.data.resize(target_size, 0u8);
-        }
-
-        while self.size < target_size {
-            let n = stream.read(&mut self.data[self.size..target_size])?;
-            if n == 0 {
-                return Err(io::Error::from(io::ErrorKind::BrokenPipe));
-            }
-            self.size += n;
-        }
-        Ok(())
-    }
-}
-
 pub struct TcpReceiver<T> {
     pub(crate) stream: BufReader<NonBlockingWriter<mio::net::TcpStream>>,
-    unacked: u32,
     poisoned: bool,
-
-    // A value of zero for window makes the channel unbounded. None means that the window size is
-    // not yet known.
-    window: Option<u32>,
-    // Holds the bytes of the window size until it is known.
-    window_buf: Buffer,
-
     deserialize_receiver: DeserializeReceiver<T>,
 
     phantom: PhantomData<T>,
@@ -172,13 +118,7 @@ where
     pub fn new(stream: mio::net::TcpStream) -> Self {
         Self {
             stream: BufReader::new(NonBlockingWriter::new(stream)),
-            unacked: 0,
             poisoned: false,
-            window: None,
-            window_buf: Buffer {
-                data: vec![0u8; 4],
-                size: 0,
-            },
             deserialize_receiver: DeserializeReceiver::new(),
             phantom: PhantomData,
         }
@@ -197,17 +137,6 @@ where
         self.stream.get_ref().get_ref().local_addr()
     }
 
-    fn send_ack(&mut self) {
-        match self.stream.get_mut().write(&[0u8]) {
-            Ok(n) => assert_eq!(n, 1),
-            Err(ref e) if e.kind() == io::ErrorKind::BrokenPipe => {}
-            Err(ref e) if e.kind() == io::ErrorKind::ConnectionReset => {}
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => unreachable!(),
-            Err(_) => self.poisoned = true,
-        }
-        self.unacked = 0;
-    }
-
     pub fn is_empty(&self) -> bool {
         self.stream.is_empty()
     }
@@ -217,40 +146,8 @@ where
             return Err(TryRecvError::Disconnected);
         }
 
-        if self.window.is_none() {
-            match self.window_buf.fill_from(&mut self.stream, 4) {
-                Ok(()) => {}
-                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    return Err(TryRecvError::Empty)
-                }
-                _ => {
-                    self.poisoned = true;
-                    return Err(TryRecvError::Disconnected);
-                }
-            }
-            self.window = Some(NetworkEndian::read_u32(&self.window_buf.data[0..4]));
-        }
-
-        // Make sure that any previously issued ACKs are sent out on the wire.
-        match self.stream.get_mut().flush() {
-            Ok(()) => {}
-            Err(ref e) if e.kind() == io::ErrorKind::BrokenPipe => {}
-            Err(ref e) if e.kind() == io::ErrorKind::ConnectionReset => {}
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => return Err(TryRecvError::Empty),
-            Err(_) => {
-                self.poisoned = true;
-                return Err(TryRecvError::Disconnected);
-            }
-        }
-
         match self.deserialize_receiver.try_recv(&mut self.stream) {
-            Ok(msg) => {
-                self.unacked = self.unacked.saturating_add(1);
-                if self.unacked == *self.window.as_ref().unwrap() {
-                    self.send_ack();
-                }
-                Ok(msg)
-            }
+            Ok(msg) => Ok(msg),
             Err(ReceiveError::WouldBlock) => Err(TryRecvError::Empty),
             Err(ReceiveError::IoError(_)) => {
                 self.poisoned = true;
@@ -285,10 +182,12 @@ impl<T> Evented for TcpReceiver<T> {
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.stream
-            .get_ref()
-            .get_ref()
-            .register(poll, token, interest, opts)
+        self.stream.get_ref().get_ref().register(
+            poll,
+            token,
+            interest,
+            opts,
+        )
     }
 
     fn reregister(
@@ -298,10 +197,12 @@ impl<T> Evented for TcpReceiver<T> {
         interest: Ready,
         opts: PollOpt,
     ) -> io::Result<()> {
-        self.stream
-            .get_ref()
-            .get_ref()
-            .reregister(poll, token, interest, opts)
+        self.stream.get_ref().get_ref().reregister(
+            poll,
+            token,
+            interest,
+            opts,
+        )
     }
 
     fn deregister(&self, poll: &Poll) -> io::Result<()> {
@@ -334,7 +235,7 @@ mod tests {
     use mio::Events;
 
     #[test]
-    fn unbounded() {
+    fn it_works() {
         let (mut sender, mut receiver) = channel::<u32>("127.0.0.1:0".parse().unwrap());
 
         sender.send(12).unwrap();
@@ -347,21 +248,8 @@ mod tests {
     }
 
     #[test]
-    fn bounded() {
-        let (mut sender, mut receiver) = sync_channel::<u32>("127.0.0.1:0".parse().unwrap(), 2);
-
-        sender.send(12).unwrap();
-        sender.send(65).unwrap();
-        assert_eq!(receiver.recv().unwrap(), 12);
-        assert_eq!(receiver.recv().unwrap(), 65);
-
-        sender.send(13).unwrap();
-        assert_eq!(receiver.recv().unwrap(), 13);
-    }
-
-    #[test]
-    fn bounded_multithread() {
-        let (mut sender, mut receiver) = sync_channel::<u32>("127.0.0.1:0".parse().unwrap(), 2);
+    fn multithread() {
+        let (mut sender, mut receiver) = channel::<u32>("127.0.0.1:0".parse().unwrap());
 
         let t1 = thread::spawn(move || {
             sender.send(12).unwrap();
@@ -381,7 +269,7 @@ mod tests {
 
     #[test]
     fn poll() {
-        let (mut sender, mut receiver) = sync_channel::<u32>("127.0.0.1:0".parse().unwrap(), 2);
+        let (mut sender, mut receiver) = channel::<u32>("127.0.0.1:0".parse().unwrap());
 
         let t1 = thread::spawn(move || {
             sender.send(12).unwrap();
@@ -408,8 +296,8 @@ mod tests {
 
     #[test]
     fn ping_pong() {
-        let (mut sender, mut receiver) = sync_channel::<u32>("127.0.0.1:0".parse().unwrap(), 1);
-        let (mut sender2, mut receiver2) = sync_channel::<u32>("127.0.0.1:0".parse().unwrap(), 1);
+        let (mut sender, mut receiver) = channel::<u32>("127.0.0.1:0".parse().unwrap());
+        let (mut sender2, mut receiver2) = channel::<u32>("127.0.0.1:0".parse().unwrap());
 
         let t1 = thread::spawn(move || {
             let poll = Poll::new().unwrap();

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -173,8 +173,8 @@ impl DomainBuilder {
 
         let debug_tx = self.debug_addr
             .as_ref()
-            .map(|addr| TcpSender::connect(addr, None).unwrap());
-        let control_reply_tx = TcpSender::connect(&self.control_addr, None).unwrap();
+            .map(|addr| TcpSender::connect(addr).unwrap());
+        let control_reply_tx = TcpSender::connect(&self.control_addr).unwrap();
 
         let transaction_state = transactions::DomainState::new(self.index, self.ts);
         let group_commit_queues = persistence::GroupCommitQueueSet::new(
@@ -1148,7 +1148,7 @@ impl Domain {
                                     use itertools::Itertools;
 
                                     let mut chunked_replay_tx =
-                                        TcpSender::connect(&domain_addr, Some(1)).unwrap();
+                                        TcpSender::connect(&domain_addr).unwrap();
 
                                     let start = time::Instant::now();
                                     debug!(log, "starting state chunker"; "node" => %link.dst);

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -339,7 +339,7 @@ impl GroupCommitQueueSet {
         let mut send_reply = |addr: SocketAddr, reply| {
             transaction_reply_txs
                 .entry(addr.clone())
-                .or_insert_with(|| TcpSender::connect(&addr, None).unwrap())
+                .or_insert_with(|| TcpSender::connect(&addr).unwrap())
                 .send(reply)
                 .unwrap()
         };

--- a/src/controller/domain_handle.rs
+++ b/src/controller/domain_handle.rs
@@ -31,7 +31,7 @@ pub struct DomainInputHandle {
 impl DomainInputHandle {
     pub fn new(listen_addr: SocketAddr, txs: Vec<SocketAddr>) -> Result<Self, io::Error> {
         let txs: Result<Vec<_>, _> = txs.iter()
-            .map(|addr| TcpSender::connect(addr, None))
+            .map(|addr| TcpSender::connect(addr))
             .collect();
         let tx_reply = PollingLoop::new(listen_addr);
         let tx_reply_addr = tx_reply.get_listener_addr().unwrap();

--- a/src/controller/inner.rs
+++ b/src/controller/inner.rs
@@ -164,7 +164,7 @@ impl ControllerInner {
             "new worker registered from {:?}, which listens on {:?}", msg.source, remote
         );
 
-        let sender = Arc::new(Mutex::new(TcpSender::connect(remote, None)?));
+        let sender = Arc::new(Mutex::new(TcpSender::connect(remote)?));
         let ws = WorkerStatus::new(sender.clone());
         self.workers.insert(msg.source.clone(), ws);
         self.read_addrs.insert(msg.source.clone(), read_listen_addr);

--- a/src/souplet/mod.rs
+++ b/src/souplet/mod.rs
@@ -110,7 +110,7 @@ impl<A: Authority> Souplet<A> {
                 .filter(|path| path.starts_with(&prefix))
                 .collect();
 
-            match TcpSender::connect(&descriptor.internal_addr, None) {
+            match TcpSender::connect(&descriptor.internal_addr) {
                 Ok(s) => {
                     self.sender = Some(s);
                     self.last_heartbeat = Some(Instant::now());


### PR DESCRIPTION
Our TcpSender/TcpReceiver supported running in a bounded mode, although this feature was almost never used. This PR removes that code