### PR TITLE
[not for merging] SQlite Base Node Indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ run.sh
 *-log-*.json
 *.png
 *.log
+soup.db
 plotting/*.png
 
 callgrind.out.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,8 +331,10 @@ dependencies = [
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rahashmap 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -886,6 +888,15 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +920,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +938,14 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1498,6 +1522,17 @@ dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2312,10 +2347,13 @@ dependencies = [
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum libsqlite3-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e9eb7b8e152b6a01be6a4a2917248381875758250dc3df5d46caf9250341dda"
 "checksum libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0db4ec23611747ef772db1c4d650f8bd762f07b461727ec998f953c614024b75"
 "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
+"checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum md5 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "daa1004633f76cdcd5a9d83ffcfe615e30ca7a2a638fcc8b8039a2dac21289d7"
 "checksum memcached-rs 0.1.2 (git+https://github.com/jonhoo/memcached-rs.git?branch=expose-multi)" = "<none>"
@@ -2373,6 +2411,7 @@ dependencies = [
 "checksum rusoto_credential 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb6ad8cb6cb8e4538011777deebe08e26958ade7f18513914c194ac32ca92fe"
 "checksum rusoto_ec2 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06c35ca38b571fe8b63ee4f32dcb901e1cd9cd0a83d02a9a7e29a541ea38a7b8"
 "checksum rusoto_sts 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2904317285367d6e9ae686ca7482b834a2a4720a80bf03d67b57e95f0acd76b0"
+"checksum rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9409d78a5a9646685688266e1833df8f08b71ffcae1b5db6c1bfb5970d8a80f"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f312457f8a4fa31d3581a6f423a70d6c33a10b95291985df55f1ff670ec10ce8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ name = "core"
 version = "0.1.0"
 dependencies = [
  "arccstr 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom_sql 0.0.1 (git+https://github.com/ms705/nom-sql.git?rev=beb5bbb07cf0a94516cad545a2f9592af9371c54)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,6 @@ dependencies = [
  "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/benchmarks/vote/clients/localsoup/mod.rs
+++ b/benchmarks/vote/clients/localsoup/mod.rs
@@ -37,6 +37,7 @@ impl VoteClient for Client {
         };
         persistence.queue_capacity = value_t_or_exit!(args, "write-batch-size", usize);
         persistence.log_prefix = "vote".to_string();
+        persistence.persist_base_nodes = args.is_present("persist-bases");
 
         // setup db
         let mut s = graph::Setup::default();

--- a/benchmarks/vote/clients/localsoup/mod.rs
+++ b/benchmarks/vote/clients/localsoup/mod.rs
@@ -35,6 +35,8 @@ impl VoteClient for Client {
         } else {
             DurabilityMode::MemoryOnly
         };
+        let flush_ns = value_t_or_exit!(args, "flush-timeout", u32);
+        persistence.flush_timeout = time::Duration::new(0, flush_ns);
         persistence.queue_capacity = value_t_or_exit!(args, "write-batch-size", usize);
         persistence.log_prefix = "vote".to_string();
         persistence.persist_base_nodes = args.is_present("persist-bases");

--- a/benchmarks/vote/main.rs
+++ b/benchmarks/vote/main.rs
@@ -628,6 +628,13 @@ fn main() {
                         .help("Enable durability for Base nodes"),
                 )
                 .arg(
+                    Arg::with_name("persist-bases")
+                        .long("persist-bases")
+                        .takes_value(false)
+                        .requires("durability")
+                        .help("Use SQlite for base nodes"),
+                )
+                .arg(
                     Arg::with_name("retain-logs-on-exit")
                         .long("retain-logs-on-exit")
                         .takes_value(false)

--- a/benchmarks/vote/main.rs
+++ b/benchmarks/vote/main.rs
@@ -649,6 +649,13 @@ fn main() {
                         .help("Size of batches processed at base nodes."),
                 )
                 .arg(
+                    Arg::with_name("flush-timeout")
+                        .long("flush-timeout")
+                        .takes_value(true)
+                        .default_value("100000")
+                        .help("Time to wait before processing a merged packet, in nanoseconds."),
+                )
+                .arg(
                     Arg::with_name("stupid")
                         .long("stupid")
                         .help("Make the migration stupid")

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Distributary Developers"]
 
 [dependencies]
+rusqlite = "0.13.0"
 arccstr = "1.0.4"
 fnv = "1.0.5"
 serde_derive = "1.0.8"
@@ -14,6 +15,7 @@ rand = "0.4.2"
 chrono = { version = "0.4.0", features = ["serde"] }
 petgraph = { version = "0.4.11", features = ["serde-1"] }
 serde = { version = "1.0.8", features = ["rc"] }
+serde_json = "1.0.2"
 
 # git deps
 nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "beb5bbb07cf0a94516cad545a2f9592af9371c54" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ rand = "0.4.2"
 chrono = { version = "0.4.0", features = ["serde"] }
 petgraph = { version = "0.4.11", features = ["serde-1"] }
 serde = { version = "1.0.8", features = ["rc"] }
-serde_json = "1.0.2"
 
 # git deps
 nom_sql = { git = "https://github.com/ms705/nom-sql.git", rev = "beb5bbb07cf0a94516cad545a2f9592af9371c54" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The Distributary Developers"]
 
 [dependencies]
+bincode = "1.0.0"
 rusqlite = "0.13.0"
 arccstr = "1.0.4"
 fnv = "1.0.5"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,7 @@ pub mod map;
 
 pub use data::{DataType, Datas, Record, Records};
 pub use addressing::{IndexPair, LocalNodeIndex};
-pub use local::{KeyType, LookupResult, MemoryState, Row, State, Tag};
+pub use local::{KeyType, LookupResult, Row, State, Tag};
 pub use map::Map;
 pub use petgraph::graph::NodeIndex;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,9 +12,11 @@ extern crate nom_sql;
 extern crate petgraph;
 extern crate rahashmap;
 extern crate rand;
+extern crate rusqlite;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 
 pub mod addressing;
 pub mod data;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(unused_extern_crates)]
 
 extern crate arccstr;
+extern crate bincode;
 extern crate chrono;
 extern crate fnv;
 extern crate nom_sql;
@@ -16,7 +17,6 @@ extern crate rusqlite;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 
 pub mod addressing;
 pub mod data;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,7 +23,7 @@ pub mod map;
 
 pub use data::{DataType, Datas, Record, Records};
 pub use addressing::{IndexPair, LocalNodeIndex};
-pub use local::{KeyType, LookupResult, Row, State, Tag};
+pub use local::{KeyType, LookupResult, MemoryState, Row, State, Tag};
 pub use map::Map;
 pub use petgraph::graph::NodeIndex;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,3 +30,14 @@ pub use map::Map;
 pub use petgraph::graph::NodeIndex;
 
 pub type StateMap = map::Map<State>;
+
+/// Indicates to what degree updates should be persisted.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum DurabilityMode {
+    /// Don't do any durability
+    MemoryOnly,
+    /// Delete any log files on exit. Useful mainly for tests.
+    DeleteOnExit,
+    /// Persist updates to disk, and don't delete them later.
+    Permanent,
+}

--- a/core/src/local/mod.rs
+++ b/core/src/local/mod.rs
@@ -22,6 +22,12 @@ pub struct Row(pub(crate) Rc<Vec<DataType>>);
 
 unsafe impl Send for Row {}
 
+impl Row {
+    pub fn unpack(self) -> Vec<DataType> {
+        Rc::try_unwrap(self.0).unwrap()
+    }
+}
+
 impl Deref for Row {
     type Target = Vec<DataType>;
     fn deref(&self) -> &Self::Target {

--- a/core/src/local/mod.rs
+++ b/core/src/local/mod.rs
@@ -6,7 +6,7 @@ mod state;
 mod keyed_state;
 
 pub use data::{DataType, SizeOf};
-pub use self::state::State;
+pub use self::state::{MemoryState, State};
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct Tag(pub u32);

--- a/core/src/local/mod.rs
+++ b/core/src/local/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -16,6 +17,7 @@ impl Tag {
     }
 }
 
+#[derive(Clone)]
 pub struct Row(pub(crate) Rc<Vec<DataType>>);
 
 unsafe impl Send for Row {}
@@ -37,7 +39,7 @@ impl SizeOf for Row {
 }
 
 pub enum LookupResult<'a> {
-    Some(&'a [Row]),
+    Some(Cow<'a, [Row]>),
     Missing,
 }
 

--- a/core/src/local/single_state.rs
+++ b/core/src/local/single_state.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use ::*;
 use rand::{Rng, ThreadRng};
 use local::keyed_state::KeyedState;
@@ -322,13 +324,13 @@ impl SingleState {
     }
     pub fn lookup<'a>(&'a self, key: &KeyType) -> LookupResult<'a> {
         if let Some(rs) = self.state.lookup(key) {
-            LookupResult::Some(&rs[..])
+            LookupResult::Some(Cow::Borrowed(&rs[..]))
         } else {
             if self.partial() {
                 // partially materialized, so this is a hole (empty results would be vec![])
                 LookupResult::Missing
             } else {
-                LookupResult::Some(&[])
+                LookupResult::Some(Cow::Owned(vec![]))
             }
         }
     }

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -176,8 +176,8 @@ impl PersistentState {
         connection
             .execute_batch(
                 "CREATE TABLE IF NOT EXISTS store (row BLOB);
-                PRAGMA synchronous = OFF;
-                PRAGMA journal_mode = OFF;",
+                PRAGMA synchronous = NORMAL;
+                PRAGMA journal_mode = WAL;",
             )
             .unwrap();
 
@@ -387,8 +387,10 @@ impl Drop for PersistentState {
             return;
         }
 
-        // Journal files should get deleted automatically, but just in case:
+        // Journal/WAL files should get deleted automatically, but just in case:
         let _ = fs::remove_file(format!("{}-journal", self.name));
+        let _ = fs::remove_file(format!("{}-shm", self.name));
+        let _ = fs::remove_file(format!("{}-wal", self.name));
         fs::remove_file(&self.name).unwrap();
     }
 }

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -174,7 +174,11 @@ impl PersistentState {
         };
 
         connection
-            .execute("CREATE TABLE IF NOT EXISTS store (row BLOB)", &[])
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS store (row BLOB);
+                PRAGMA synchronous = OFF;
+                PRAGMA journal_mode = OFF;",
+            )
             .unwrap();
 
         Self {

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -190,7 +190,7 @@ impl PersistentState {
                 "CREATE TABLE IF NOT EXISTS store (row BLOB);
                 PRAGMA locking_mode = EXCLUSIVE;
                 PRAGMA synchronous = OFF;
-                PRAGMA journal_mode = WAL;",
+                PRAGMA journal_mode = OFF;",
             )
             .unwrap();
 

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -64,7 +64,7 @@ impl State {
     pub fn remove(&mut self, r: &[DataType]) -> bool {
         match *self {
             State::InMemory(ref mut s) => s.remove(r),
-            _ => unreachable!(),
+            State::Persistent(ref mut s) => s.remove(r),
         }
     }
 
@@ -130,7 +130,6 @@ impl State {
 
 pub struct PersistentState {
     connection: Connection,
-    statements: HashMap<Vec<usize>, String>,
     indices: HashSet<usize>,
 }
 
@@ -159,9 +158,21 @@ impl PersistentState {
 
         Self {
             connection,
-            statements: Default::default(),
             indices: Default::default(),
         }
+    }
+
+    // Joins together a SQL clause on the form of
+    // index_0 = columns[0], index_1 = columns[1]...
+    fn build_clause<'a, I>(columns: I) -> String
+    where
+        I: Iterator<Item = &'a usize>,
+    {
+        columns
+            .enumerate()
+            .map(|(i, column)| format!("index_{} = ?{}", column, i + 1))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     fn add_key(&mut self, columns: &[usize], partial: Option<Vec<Tag>>) {
@@ -179,17 +190,6 @@ impl PersistentState {
                 )
                 .unwrap();
         }
-
-        let clauses = columns
-            .iter()
-            .enumerate()
-            .map(|(i, column)| format!("index_{} = ?{}", column, i + 1))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let statement = format!("SELECT row FROM store WHERE {}", clauses);
-        self.connection.prepare_cached(&statement).unwrap();
-        self.statements.insert(Vec::from(columns), statement);
     }
 
     fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
@@ -228,9 +228,9 @@ impl PersistentState {
     }
 
     fn lookup(&self, columns: &[usize], key: &KeyType) -> LookupResult {
-        let mut statement = self.connection
-            .prepare_cached(&self.statements[&Vec::from(columns)])
-            .unwrap();
+        let clauses = Self::build_clause(columns.iter());
+        let query = format!("SELECT row FROM store WHERE {}", clauses);
+        let mut statement = self.connection.prepare_cached(&query).unwrap();
 
         let mapper = |result: &rusqlite::Row| -> Vec<DataType> {
             let row: String = result.get(0);
@@ -253,6 +253,18 @@ impl PersistentState {
             .collect::<Vec<_>>();
 
         LookupResult::Some(Cow::Owned(data))
+    }
+
+    fn remove(&mut self, r: &[DataType]) -> bool {
+        let clauses = Self::build_clause(self.indices.iter());
+        let index_values = self.indices
+            .iter()
+            .map(|index| &r[*index] as &ToSql)
+            .collect::<Vec<&ToSql>>();
+
+        let query = format!("DELETE FROM store WHERE {}", clauses);
+        let mut statement = self.connection.prepare_cached(&query).unwrap();
+        statement.execute(&index_values[..]).unwrap() > 0
     }
 }
 

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -357,6 +357,8 @@ impl Drop for PersistentState {
             return;
         }
 
+        // Journal files should get deleted automatically, but just in case:
+        let _ = fs::remove_file(format!("{}-journal", self.name));
         fs::remove_file(&self.name).unwrap();
     }
 }

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -352,7 +352,9 @@ impl PersistentState {
 impl Drop for PersistentState {
     fn drop(&mut self) {
         match self.durability_mode {
-            DurabilityMode::DeleteOnExit => {
+            // TODO(ekmartin): We don't support recovering persistent base node indices yet,
+            // so drop the tables at the end for all modes except InMemory:
+            DurabilityMode::Permanent | DurabilityMode::DeleteOnExit => {
                 self.connection
                     .execute(&format!("DROP TABLE {}", self.name), &[])
                     .unwrap();

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -51,6 +51,10 @@ impl State {
     }
 
     pub fn process_records(&mut self, records: &Records) {
+        if records.len() == 0 {
+            return;
+        }
+
         match *self {
             State::InMemory(ref mut s) => s.process_records(records),
             State::Persistent(ref mut s) => s.process_records(records),
@@ -177,7 +181,7 @@ impl PersistentState {
             .execute_batch(
                 "CREATE TABLE IF NOT EXISTS store (row BLOB);
                 PRAGMA locking_mode = EXCLUSIVE;
-                PRAGMA synchronous = NORMAL;
+                PRAGMA synchronous = FULL;
                 PRAGMA journal_mode = WAL;",
             )
             .unwrap();

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -6,27 +6,135 @@ use ::*;
 use data::SizeOf;
 use local::single_state::SingleState;
 
+pub enum State {
+    InMemory(MemoryState),
+}
+
+impl State {
+    pub fn default() -> Self {
+        State::InMemory(MemoryState::default())
+    }
+
+    pub fn base() -> Self {
+        State::InMemory(MemoryState::default())
+    }
+
+    /// Add an index keyed by the given columns and replayed to by the given partial tags.
+    pub fn add_key(&mut self, columns: &[usize], partial: Option<Vec<Tag>>) {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.add_key(columns, partial),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn keys(&self) -> Vec<Vec<usize>> {
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.keys(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn is_useful(&self) -> bool {
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.is_useful(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn is_partial(&self) -> bool {
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.is_partial(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.insert(r, partial_tag),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn remove(&mut self, r: &[DataType]) -> bool {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.remove(r),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn mark_hole(&mut self, key: &[DataType], tag: &Tag) {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.mark_hole(key, tag),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn mark_filled(&mut self, key: Vec<DataType>, tag: &Tag) {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.mark_filled(key, tag),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn lookup<'a>(&'a self, columns: &[usize], key: &KeyType) -> LookupResult<'a> {
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.lookup(columns, key),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn rows(&self) -> usize {
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.rows(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn cloned_records(&self) -> Vec<Vec<DataType>> {
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.cloned_records(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.clear(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn evict_random_keys(&mut self, count: usize) -> (&[usize], Vec<Vec<DataType>>, u64) {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.evict_random_keys(count),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Evict the listed keys from the materialization targeted by `tag`.
+    pub fn evict_keys(&mut self, tag: &Tag, keys: &[Vec<DataType>]) -> (&[usize], u64) {
+        match *self {
+            State::InMemory(ref mut memory_state) => memory_state.evict_keys(tag, keys),
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(Default)]
-pub struct State {
+pub struct MemoryState {
     state: Vec<SingleState>,
     by_tag: HashMap<Tag, usize>,
     mem_size: u64,
 }
 
-impl State {
-    /// Construct base materializations differently (potentially)
-    pub fn base() -> Self {
-        Self::default()
-    }
-
+impl MemoryState {
     /// Returns the index in `self.state` of the index keyed on `cols`, or None if no such index
     /// exists.
     fn state_for(&self, cols: &[usize]) -> Option<usize> {
         self.state.iter().position(|s| s.key() == cols)
     }
 
-    /// Add an index keyed by the given columns and replayed to by the given partial tags.
-    pub fn add_key(&mut self, columns: &[usize], partial: Option<Vec<Tag>>) {
+    fn add_key(&mut self, columns: &[usize], partial: Option<Vec<Tag>>) {
         let (i, exists) = if let Some(i) = self.state_for(columns) {
             // already keyed by this key; just adding tags
             (i, true)
@@ -64,21 +172,21 @@ impl State {
     }
 
     /// Returns a Vec of all keys that currently exist on this materialization.
-    pub fn keys(&self) -> Vec<Vec<usize>> {
+    fn keys(&self) -> Vec<Vec<usize>> {
         self.state.iter().map(|s| s.key().to_vec()).collect()
     }
 
     /// Returns whether this state is currently keyed on anything. If not, then it cannot store any
     /// infromation and is thus "not useful".
-    pub fn is_useful(&self) -> bool {
+    fn is_useful(&self) -> bool {
         !self.state.is_empty()
     }
 
-    pub fn is_partial(&self) -> bool {
+    fn is_partial(&self) -> bool {
         self.state.iter().any(|s| s.partial())
     }
 
-    pub fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
+    fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
         let r = Rc::new(r);
 
         if let Some(tag) = partial_tag {
@@ -105,7 +213,7 @@ impl State {
         }
     }
 
-    pub fn remove(&mut self, r: &[DataType]) -> bool {
+    fn remove(&mut self, r: &[DataType]) -> bool {
         let mut hit = false;
         for s in &mut self.state {
             if let Some(row) = s.remove_row(r, &mut hit) {
@@ -118,23 +226,23 @@ impl State {
         hit
     }
 
-    pub fn rows(&self) -> usize {
+    fn rows(&self) -> usize {
         self.state.iter().map(|s| s.rows()).sum()
     }
 
-    pub fn mark_filled(&mut self, key: Vec<DataType>, tag: &Tag) {
+    fn mark_filled(&mut self, key: Vec<DataType>, tag: &Tag) {
         debug_assert!(!self.state.is_empty(), "filling uninitialized index");
         let index = self.by_tag[tag];
         self.state[index].mark_filled(key);
     }
 
-    pub fn mark_hole(&mut self, key: &[DataType], tag: &Tag) {
+    fn mark_hole(&mut self, key: &[DataType], tag: &Tag) {
         debug_assert!(!self.state.is_empty(), "filling uninitialized index");
         let index = self.by_tag[tag];
         self.state[index].mark_hole(key);
     }
 
-    pub fn lookup<'a>(&'a self, columns: &[usize], key: &KeyType) -> LookupResult<'a> {
+    fn lookup<'a>(&'a self, columns: &[usize], key: &KeyType) -> LookupResult<'a> {
         debug_assert!(!self.state.is_empty(), "lookup on uninitialized index");
         let index = self.state_for(columns)
             .expect("lookup on non-indexed column set");
@@ -142,7 +250,7 @@ impl State {
     }
 
     /// Return a copy of all records. Panics if the state is only partially materialized.
-    pub fn cloned_records(&self) -> Vec<Vec<DataType>> {
+    fn cloned_records(&self) -> Vec<Vec<DataType>> {
         fn fix<'a>(rs: &'a Vec<Row>) -> impl Iterator<Item = Vec<DataType>> + 'a {
             rs.iter().map(|r| Vec::clone(&**r))
         }
@@ -151,7 +259,7 @@ impl State {
         self.state[0].values().flat_map(fix).collect()
     }
 
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         for s in &mut self.state {
             s.clear();
         }
@@ -160,7 +268,7 @@ impl State {
 
     /// Evict `count` randomly selected keys, returning key colunms of the index chosen to evict
     /// from along with the keys evicted and the number of bytes evicted.
-    pub fn evict_random_keys(&mut self, count: usize) -> (&[usize], Vec<Vec<DataType>>, u64) {
+    fn evict_random_keys(&mut self, count: usize) -> (&[usize], Vec<Vec<DataType>>, u64) {
         let mut rng = rand::thread_rng();
         let index = rng.gen_range(0, self.state.len());
         let (bytes_freed, keys) = self.state[index].evict_random_keys(count, &mut rng);
@@ -170,7 +278,7 @@ impl State {
 
     /// Evict the listed keys from the materialization targeted by `tag`, returning the key columns
     /// of the index that was evicted from and the number of bytes evicted.
-    pub fn evict_keys(&mut self, tag: &Tag, keys: &[Vec<DataType>]) -> (&[usize], u64) {
+    fn evict_keys(&mut self, tag: &Tag, keys: &[Vec<DataType>]) -> (&[usize], u64) {
         let index = self.by_tag[tag];
         let bytes = self.state[index].evict_keys(keys);
         self.mem_size = self.mem_size.saturating_sub(bytes);
@@ -186,6 +294,9 @@ impl SizeOf for State {
     }
 
     fn deep_size_of(&self) -> u64 {
-        self.mem_size
+        match *self {
+            State::InMemory(ref memory_state) => memory_state.mem_size,
+            _ => unreachable!(),
+        }
     }
 }

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -187,7 +187,6 @@ impl PersistentState {
             .collect::<Vec<_>>()
             .join(", ");
 
-        println!("clauses {:?}", clauses);
         let statement = format!("SELECT row FROM store WHERE {}", clauses);
         self.connection.prepare_cached(&statement).unwrap();
         self.statements.insert(Vec::from(columns), statement);
@@ -209,7 +208,6 @@ impl PersistentState {
             .collect::<Vec<String>>()
             .join(", ");
 
-        println!("INSERT INTO STORE ({}) VALUES ({})", columns, placeholders);
         let mut statement = self.connection
             .prepare_cached(&format!(
                 "INSERT INTO store ({}) VALUES ({})",
@@ -218,23 +216,10 @@ impl PersistentState {
             .unwrap();
 
         let row = serde_json::to_string(&r).unwrap();
-        // match self.indices.len() {
-        //      1 => statement.execute(&[&row, ]
-        //      _ => unreachable!()
-        //      // KeyType::Double((a, b)) => statement.execute(&[&a, &b]),
-        //      // KeyType::Tri((a, b, c)) => statement.execute(&[&a, &b, &c]),
-        //      // KeyType::Quad((a, b, c, d)) => statement.execute(&[&a, &b, &c, &d]),
-        //      // KeyType::Quin((a, b, c, d, e)) => statement.execute(&[&a, &b, &c, &d, &e]),
-        //      // KeyType::Sex((a, b, c, d, e, f)) => statement.execute(&[&a, &b, &c, &d, &e, &f]),
-        // }.unwrap();
-
         let mut values: Vec<&ToSql> = vec![&row];
         let mut index_values = self.indices
             .iter()
-            .map(|index| {
-                println!("index value {}", r[*index]);
-                &r[*index] as &ToSql
-            })
+            .map(|index| &r[*index] as &ToSql)
             .collect::<Vec<&ToSql>>();
 
         values.append(&mut index_values);
@@ -247,20 +232,20 @@ impl PersistentState {
             .prepare_cached(&self.statements[&Vec::from(columns)])
             .unwrap();
 
-        println!("looking up {}", self.statements[&Vec::from(columns)]);
+        let mapper = |result: &rusqlite::Row| -> Vec<DataType> {
+            let row: String = result.get(0);
+            serde_json::from_str(&row).unwrap()
+        };
+
         let rows = match *key {
-             KeyType::Single(a) => statement.query_map(&[a], |row| {
-                 let string: String = row.get(0);
-                 println!("got row {:?}", string);
-                 let data_row: Vec<DataType> = serde_json::from_str(&string).unwrap();
-                 data_row
-             }),
-             _ => unreachable!()
-             // KeyType::Double((a, b)) => statement.execute(&[&a, &b]),
-             // KeyType::Tri((a, b, c)) => statement.execute(&[&a, &b, &c]),
-             // KeyType::Quad((a, b, c, d)) => statement.execute(&[&a, &b, &c, &d]),
-             // KeyType::Quin((a, b, c, d, e)) => statement.execute(&[&a, &b, &c, &d, &e]),
-             // KeyType::Sex((a, b, c, d, e, f)) => statement.execute(&[&a, &b, &c, &d, &e, &f]),
+            KeyType::Single(a) => statement.query_map(&[a], mapper),
+            KeyType::Double(ref r) => statement.query_map(&[&r.0, &r.1], mapper),
+            KeyType::Tri(ref r) => statement.query_map(&[&r.0, &r.1, &r.2], mapper),
+            KeyType::Quad(ref r) => statement.query_map(&[&r.0, &r.1, &r.2, &r.3], mapper),
+            KeyType::Quin(ref r) => statement.query_map(&[&r.0, &r.1, &r.2, &r.3, &r.4], mapper),
+            KeyType::Sex(ref r) => {
+                statement.query_map(&[&r.0, &r.1, &r.2, &r.3, &r.4, &r.5], mapper)
+            }
         };
 
         let data = rows.unwrap()

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -176,6 +176,7 @@ impl PersistentState {
         connection
             .execute_batch(
                 "CREATE TABLE IF NOT EXISTS store (row BLOB);
+                PRAGMA locking_mode = EXCLUSIVE;
                 PRAGMA synchronous = NORMAL;
                 PRAGMA journal_mode = WAL;",
             )

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -50,17 +50,27 @@ impl State {
         }
     }
 
+    pub fn process_records(&mut self, records: &Records) {
+        match *self {
+            State::InMemory(ref mut s) => s.process_records(records),
+            State::Persistent(ref mut s) => s.process_records(records),
+        }
+    }
+
     pub fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
         match *self {
             State::InMemory(ref mut s) => s.insert(r, partial_tag),
-            State::Persistent(ref mut s) => s.insert(r, partial_tag),
+            State::Persistent(ref mut s) => {
+                assert!(partial_tag.is_none(), "Bases can't be partial");
+                PersistentState::insert(r, &s.indices, &s.connection)
+            }
         }
     }
 
     pub fn remove(&mut self, r: &[DataType]) -> bool {
         match *self {
             State::InMemory(ref mut s) => s.remove(r),
-            State::Persistent(ref mut s) => s.remove(r),
+            State::Persistent(ref mut s) => PersistentState::remove(r, &s.indices, &s.connection),
         }
     }
 
@@ -194,6 +204,55 @@ impl PersistentState {
         bincode::deserialize(&row).unwrap()
     }
 
+    // Builds up an INSERT query on the form of:
+    // `INSERT INTO store (index_0, index_1, row) VALUES (...)`
+    // where row is a serialized representation of r.
+    fn insert(r: Vec<DataType>, indices: &HashSet<usize>, connection: &Connection) -> bool {
+        let columns = format!(
+            "row, {}",
+            indices
+                .iter()
+                .map(|index| format!("index_{}", index))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+
+        let placeholders = (1..(indices.len() + 2))
+            .map(|placeholder| format!("?{}", placeholder))
+            .collect::<Vec<String>>()
+            .join(", ");
+
+        let mut statement = connection
+            .prepare_cached(&format!(
+                "INSERT INTO store ({}) VALUES ({})",
+                columns, placeholders
+            ))
+            .unwrap();
+
+        let row = bincode::serialize(&r).unwrap();
+        let mut values: Vec<&ToSql> = vec![&row];
+        let mut index_values = indices
+            .iter()
+            .map(|index| &r[*index] as &ToSql)
+            .collect::<Vec<&ToSql>>();
+
+        values.append(&mut index_values);
+        statement.execute(&values[..]).unwrap();
+        true
+    }
+
+    fn remove(r: &[DataType], indices: &HashSet<usize>, connection: &Connection) -> bool {
+        let clauses = Self::build_clause(indices.iter());
+        let index_values = indices
+            .iter()
+            .map(|index| &r[*index] as &ToSql)
+            .collect::<Vec<&ToSql>>();
+
+        let query = format!("DELETE FROM store WHERE {}", clauses);
+        let mut statement = connection.prepare_cached(&query).unwrap();
+        statement.execute(&index_values[..]).unwrap() > 0
+    }
+
     fn add_key(&mut self, columns: &[usize], partial: Option<Vec<Tag>>) {
         assert!(partial.is_none(), "Bases can't be partial");
         // Add each of the individual index columns (index_0, index_1...):
@@ -235,49 +294,28 @@ impl PersistentState {
             let rows = self.cloned_records();
             self.clear();
             for row in rows {
-                self.insert(row, None);
+                Self::insert(row, &self.indices, &mut self.connection);
             }
         }
 
         self.connection.execute(&index_query, &[]).unwrap();
     }
 
-    // Builds up an INSERT query on the form of:
-    // `INSERT INTO store (index_0, index_1, row) VALUES (...)`
-    // where row is a serialized representation of r.
-    fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
-        assert!(partial_tag.is_none(), "Bases can't be partial");
-        let columns = format!(
-            "row, {}",
-            self.indices
-                .iter()
-                .map(|index| format!("index_{}", index))
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
+    fn process_records(&mut self, records: &Records) {
+        let transaction = self.connection.transaction().unwrap();
+        for r in records.iter() {
+            match *r {
+                Record::Positive(ref r) => {
+                    Self::insert(r.clone(), &self.indices, &transaction);
+                }
+                Record::Negative(ref r) => {
+                    Self::remove(r, &self.indices, &transaction);
+                }
+                Record::DeleteRequest(..) => unreachable!(),
+            }
+        }
 
-        let placeholders = (1..(self.indices.len() + 2))
-            .map(|placeholder| format!("?{}", placeholder))
-            .collect::<Vec<String>>()
-            .join(", ");
-
-        let mut statement = self.connection
-            .prepare_cached(&format!(
-                "INSERT INTO store ({}) VALUES ({})",
-                columns, placeholders
-            ))
-            .unwrap();
-
-        let row = bincode::serialize(&r).unwrap();
-        let mut values: Vec<&ToSql> = vec![&row];
-        let mut index_values = self.indices
-            .iter()
-            .map(|index| &r[*index] as &ToSql)
-            .collect::<Vec<&ToSql>>();
-
-        values.append(&mut index_values);
-        statement.execute(&values[..]).unwrap();
-        true
+        transaction.commit().unwrap();
     }
 
     // Retrieves rows from SQlite by building up a SELECT query on the form of
@@ -305,18 +343,6 @@ impl PersistentState {
             .collect::<Vec<_>>();
 
         LookupResult::Some(Cow::Owned(data))
-    }
-
-    fn remove(&mut self, r: &[DataType]) -> bool {
-        let clauses = Self::build_clause(self.indices.iter());
-        let index_values = self.indices
-            .iter()
-            .map(|index| &r[*index] as &ToSql)
-            .collect::<Vec<&ToSql>>();
-
-        let query = format!("DELETE FROM store WHERE {}", clauses);
-        let mut statement = self.connection.prepare_cached(&query).unwrap();
-        statement.execute(&index_values[..]).unwrap() > 0
     }
 
     fn cloned_records(&self) -> Vec<Vec<DataType>> {
@@ -427,6 +453,22 @@ impl MemoryState {
 
     fn is_partial(&self) -> bool {
         self.state.iter().any(|s| s.partial())
+    }
+
+    fn process_records(&mut self, records: &Records) {
+        for r in records.iter() {
+            match *r {
+                Record::Positive(ref r) => {
+                    let hit = self.insert(r.clone(), None);
+                    debug_assert!(hit);
+                }
+                Record::Negative(ref r) => {
+                    let hit = self.remove(r);
+                    debug_assert!(hit);
+                }
+                Record::DeleteRequest(..) => unreachable!(),
+            }
+        }
     }
 
     fn insert(&mut self, r: Vec<DataType>, partial_tag: Option<Tag>) -> bool {
@@ -767,6 +809,45 @@ mod tests {
             LookupResult::Some(rows) => assert_eq!(&*rows[0], &row),
             _ => unreachable!(),
         };
+    }
+
+    fn process_records(mut state: State) {
+        let records: Records = vec![
+            (vec![1.into(), "A".into()], true),
+            (vec![2.into(), "B".into()], true),
+            (vec![3.into(), "C".into()], true),
+            (vec![1.into(), "A".into()], false),
+        ].into();
+
+        state.add_key(&[0], None);
+        state.process_records(&records);
+
+        // Make sure the first record has been deleted:
+        match state.lookup(&[0], &KeyType::Single(&records[0][0])) {
+            LookupResult::Some(rows) => assert_eq!(rows.len(), 0),
+            _ => unreachable!(),
+        };
+
+        // Then check that the rest exist:
+        for i in 1..3 {
+            let record = &records[i];
+            match state.lookup(&[0], &KeyType::Single(&record[0])) {
+                LookupResult::Some(rows) => assert_eq!(&*rows[0], &**record),
+                _ => unreachable!(),
+            };
+        }
+    }
+
+    #[test]
+    fn persistent_state_process_records() {
+        let state = setup_persistent();
+        process_records(state);
+    }
+
+    #[test]
+    fn memory_state_process_records() {
+        let state = State::default();
+        process_records(state);
     }
 
     #[test]

--- a/core/src/local/state.rs
+++ b/core/src/local/state.rs
@@ -152,7 +152,7 @@ impl ToSql for DataType {
 
 impl PersistentState {
     fn initialize() -> Self {
-        let connection = Connection::open("sqlite_db").unwrap();
+        let connection = Connection::open_in_memory().unwrap();
         connection
             .execute("CREATE TABLE store (row BLOB)", &[])
             .unwrap();

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1266,16 +1266,18 @@ impl Domain {
                         if !index.is_empty() {
                             let mut s = {
                                 let n = self.nodes[&node].borrow();
-                                if n.is_internal() && n.get_base().is_some() {
-                                    State::base(
-                                        format!(
-                                            "{}_{}_{}",
-                                            self.persistence_parameters.log_prefix,
-                                            n.name(),
-                                            self.shard.unwrap_or(0),
-                                        ),
-                                        self.persistence_parameters.mode.clone(),
-                                    )
+                                let params = &self.persistence_parameters;
+                                if n.is_internal() && n.get_base().is_some()
+                                    && params.persist_base_nodes
+                                {
+                                    let base_name = format!(
+                                        "{}_{}_{}",
+                                        params.log_prefix,
+                                        n.name(),
+                                        self.shard.unwrap_or(0),
+                                    );
+
+                                    State::base(base_name, params.mode.clone())
                                 } else {
                                     State::default()
                                 }

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1267,7 +1267,15 @@ impl Domain {
                             let mut s = {
                                 let n = self.nodes[&node].borrow();
                                 if n.is_internal() && n.get_base().is_some() {
-                                    State::base()
+                                    State::base(
+                                        format!(
+                                            "{}_{}_{}",
+                                            self.persistence_parameters.log_prefix,
+                                            n.name(),
+                                            self.shard.unwrap_or(0),
+                                        ),
+                                        self.persistence_parameters.mode.clone(),
+                                    )
                                 } else {
                                     State::default()
                                 }

--- a/dataflow/src/domain/mod.rs
+++ b/dataflow/src/domain/mod.rs
@@ -1413,15 +1413,16 @@ impl Domain {
         }
 
         let n = self.nodes[&source].borrow();
+        let data: &Vec<DataType> = &*row;
         if n.is_internal() {
             if let Some(b) = n.get_base() {
-                let mut row = ((*row).clone(), true).into();
+                let mut row = (data.clone(), true).into();
                 b.fix(&mut row);
                 return row;
             }
         }
 
-        return ((*row).clone(), true).into();
+        return (data.clone(), true).into();
     }
 
     fn seed_all(&mut self, tag: Tag, keys: HashSet<Vec<DataType>>, sends: &mut EnqueuedSends) {

--- a/dataflow/src/lib.rs
+++ b/dataflow/src/lib.rs
@@ -57,7 +57,6 @@ pub type Readers = Arc<
 pub type PersistenceParameters = persistence::Parameters;
 pub type DomainConfig = domain::Config;
 
-pub use persistence::DurabilityMode;
 pub use domain::{Domain, DomainBuilder, Index};
 pub use payload::{LocalBypass, Packet};
 pub use checktable::connect_thread_checktable;

--- a/dataflow/src/node/process.rs
+++ b/dataflow/src/node/process.rs
@@ -277,18 +277,6 @@ pub fn materialize(rs: &mut Records, partial: Option<Tag>, state: Option<&mut St
             }
         });
     } else {
-        for r in rs.iter() {
-            match *r {
-                Record::Positive(ref r) => {
-                    let hit = state.insert(r.clone(), None);
-                    debug_assert!(hit);
-                }
-                Record::Negative(ref r) => {
-                    let hit = state.remove(r);
-                    debug_assert!(hit);
-                }
-                Record::DeleteRequest(..) => unreachable!(),
-            }
-        }
+        state.process_records(rs);
     }
 }

--- a/dataflow/src/ops/filter.rs
+++ b/dataflow/src/ops/filter.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync;
 
@@ -142,11 +143,12 @@ impl Ingredient for Filter {
         columns: &[usize],
         key: &KeyType,
         states: &'a StateMap,
-    ) -> Option<Option<Box<Iterator<Item = &'a [DataType]> + 'a>>> {
+    ) -> Option<Option<Box<Iterator<Item = Cow<'a, [DataType]>> + 'a>>> {
         states.get(&*self.src).and_then(|state| {
             let f = self.filter.clone();
             match state.lookup(columns, key) {
-                LookupResult::Some(rs) => {
+                // TODO(ekmartin): try to refactor these (almost) duplicate branches:
+                LookupResult::Some(Cow::Borrowed(rs)) => {
                     let r = Box::new(
                         rs.iter()
                             .filter(move |r| {
@@ -171,7 +173,33 @@ impl Ingredient for Filter {
                                     }
                                 })
                             })
-                            .map(|r| &r[..]),
+                            .map(|r| Cow::from(&r[..])),
+                    ) as Box<_>;
+                    Some(Some(r))
+                }
+                LookupResult::Some(Cow::Owned(rs)) => {
+                    let r = Box::new(
+                        rs.into_iter()
+                            .filter(move |r| {
+                                r.iter().enumerate().all(|(i, d)| {
+                                    // check if this filter matches
+                                    if let Some((ref op, ref f)) = f[i] {
+                                        match *op {
+                                            Operator::Equal => d == f,
+                                            Operator::NotEqual => d != f,
+                                            Operator::Greater => d > f,
+                                            Operator::GreaterOrEqual => d >= f,
+                                            Operator::Less => d < f,
+                                            Operator::LessOrEqual => d <= f,
+                                            _ => unimplemented!(),
+                                        }
+                                    } else {
+                                        // everything matches no condition
+                                        true
+                                    }
+                                })
+                            })
+                            .map(|r| Cow::from(r.unpack())),
                     ) as Box<_>;
                     Some(Some(r))
                 }

--- a/dataflow/src/ops/filter.rs
+++ b/dataflow/src/ops/filter.rs
@@ -146,59 +146,38 @@ impl Ingredient for Filter {
     ) -> Option<Option<Box<Iterator<Item = Cow<'a, [DataType]>> + 'a>>> {
         states.get(&*self.src).and_then(|state| {
             let f = self.filter.clone();
+            let filter = move |r: &&Row| {
+                r.iter().enumerate().all(|(i, d)| {
+                    // check if this filter matches
+                    if let Some(ref cond) = f[i] {
+                        match *cond {
+                            FilterCondition::Equality(ref op, ref f) => match *op {
+                                Operator::Equal => d == f,
+                                Operator::NotEqual => d != f,
+                                Operator::Greater => d > f,
+                                Operator::GreaterOrEqual => d >= f,
+                                Operator::Less => d < f,
+                                Operator::LessOrEqual => d <= f,
+                                _ => unimplemented!(),
+                            },
+                            FilterCondition::In(ref fs) => fs.contains(d),
+                        }
+                    } else {
+                        // everything matches no condition
+                        true
+                    }
+                })
+            };
+
             match state.lookup(columns, key) {
-                // TODO(ekmartin): try to refactor these (almost) duplicate branches:
                 LookupResult::Some(Cow::Borrowed(rs)) => {
-                    let r = Box::new(
-                        rs.iter()
-                            .filter(move |r| {
-                                r.iter().enumerate().all(|(i, d)| {
-                                    // check if this filter matches
-                                    if let Some(ref cond) = f[i] {
-                                        match *cond {
-                                            FilterCondition::Equality(ref op, ref f) => match *op {
-                                                Operator::Equal => d == f,
-                                                Operator::NotEqual => d != f,
-                                                Operator::Greater => d > f,
-                                                Operator::GreaterOrEqual => d >= f,
-                                                Operator::Less => d < f,
-                                                Operator::LessOrEqual => d <= f,
-                                                _ => unimplemented!(),
-                                            },
-                                            FilterCondition::In(ref fs) => fs.contains(d),
-                                        }
-                                    } else {
-                                        // everything matches no condition
-                                        true
-                                    }
-                                })
-                            })
-                            .map(|r| Cow::from(&r[..])),
-                    ) as Box<_>;
+                    let r = Box::new(rs.iter().filter(filter).map(|r| Cow::from(&r[..]))) as Box<_>;
                     Some(Some(r))
                 }
                 LookupResult::Some(Cow::Owned(rs)) => {
                     let r = Box::new(
                         rs.into_iter()
-                            .filter(move |r| {
-                                r.iter().enumerate().all(|(i, d)| {
-                                    // check if this filter matches
-                                    if let Some((ref op, ref f)) = f[i] {
-                                        match *op {
-                                            Operator::Equal => d == f,
-                                            Operator::NotEqual => d != f,
-                                            Operator::Greater => d > f,
-                                            Operator::GreaterOrEqual => d >= f,
-                                            Operator::Less => d < f,
-                                            Operator::LessOrEqual => d <= f,
-                                            _ => unimplemented!(),
-                                        }
-                                    } else {
-                                        // everything matches no condition
-                                        true
-                                    }
-                                })
-                            })
+                            .filter(move |ref r| filter(r))
                             .map(|r| Cow::from(r.unpack())),
                     ) as Box<_>;
                     Some(Some(r))

--- a/dataflow/src/ops/grouped/mod.rs
+++ b/dataflow/src/ops/grouped/mod.rs
@@ -197,11 +197,11 @@ where
                         }
                     }
 
-                    let old = {
+                    let rs = {
                         match db.lookup(&out_key[..], &KeyType::from(&group[..])) {
                             LookupResult::Some(rs) => {
                                 debug_assert!(rs.len() <= 1, "a group had more than 1 result");
-                                rs.get(0)
+                                rs
                             }
                             LookupResult::Missing => {
                                 misses.push(Miss {
@@ -222,6 +222,7 @@ where
                         }
                     };
 
+                    let old = rs.get(0);
                     let (current, new) = {
                         use std::borrow::Cow;
 

--- a/dataflow/src/ops/join.rs
+++ b/dataflow/src/ops/join.rs
@@ -415,26 +415,26 @@ impl Ingredient for Join {
                     while other_rows.peek().is_some() {
                         if let Some(false) = make_null {
                             // we need to generate a -NULL for all these lefts
-                            ret.push((self.generate_null(other), false).into());
+                            ret.push((self.generate_null(&other), false).into());
                         }
                         if from == *self.left {
                             ret.push(
                                 (
-                                    self.generate_row(&row, other, Preprocessed::Neither),
+                                    self.generate_row(&row, &other, Preprocessed::Neither),
                                     positive,
                                 ).into(),
                             );
                         } else {
                             ret.push(
                                 (
-                                    self.generate_row(other, &row, Preprocessed::Neither),
+                                    self.generate_row(&other, &row, Preprocessed::Neither),
                                     positive,
                                 ).into(),
                             );
                         }
                         if let Some(true) = make_null {
                             // we need to generate a +NULL for all these lefts
-                            ret.push((self.generate_null(other), true).into());
+                            ret.push((self.generate_null(&other), true).into());
                         }
                         other = other_rows.next().unwrap();
                         other_rows_count += 1;
@@ -442,17 +442,17 @@ impl Ingredient for Join {
 
                     if let Some(false) = make_null {
                         // we need to generate a -NULL for the last left too
-                        ret.push((self.generate_null(other), false).into());
+                        ret.push((self.generate_null(&other), false).into());
                     }
                     ret.push(
                         (
-                            self.regenerate_row(row, other, from == *self.left, false),
+                            self.regenerate_row(row, &other, from == *self.left, false),
                             positive,
                         ).into(),
                     );
                     if let Some(true) = make_null {
                         // we need to generate a +NULL for the last left too
-                        ret.push((self.generate_null(other), true).into());
+                        ret.push((self.generate_null(&other), true).into());
                     }
                 } else if other_rows_count == 0 {
                     if self.kind == JoinType::Left && from == *self.left {

--- a/dataflow/src/ops/latest.rs
+++ b/dataflow/src/ops/latest.rs
@@ -90,7 +90,7 @@ impl Ingredient for Latest {
                 match db.lookup(&[self.key[0]], &KeyType::Single(&r[self.key[0]])) {
                     LookupResult::Some(rs) => {
                         debug_assert!(rs.len() <= 1, "a group had more than 1 result");
-                        Some((r, rs.get(0)))
+                        Some((r, rs))
                     }
                     LookupResult::Missing => {
                         // we don't actively materialize holes unless requested by a read. this
@@ -113,8 +113,8 @@ impl Ingredient for Latest {
             });
 
             // buffer emitted records
-            for (r, current) in currents {
-                if let Some(current) = current {
+            for (r, current_row) in currents {
+                if let Some(current) = current_row.get(0) {
                     out.push(Record::Negative((**current).clone()));
                 }
 

--- a/dataflow/src/ops/mod.rs
+++ b/dataflow/src/ops/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use prelude::*;
@@ -189,7 +190,7 @@ impl Ingredient for NodeOperator {
         columns: &[usize],
         key: &KeyType,
         states: &'a StateMap,
-    ) -> Option<Option<Box<Iterator<Item = &'a [DataType]> + 'a>>> {
+    ) -> Option<Option<Box<Iterator<Item = Cow<'a, [DataType]>> + 'a>>> {
         impl_ingredient_fn_ref!(self, query_through, columns, key, states)
     }
     fn lookup<'a>(
@@ -199,7 +200,7 @@ impl Ingredient for NodeOperator {
         key: &KeyType,
         domain: &DomainNodes,
         states: &'a StateMap,
-    ) -> Option<Option<Box<Iterator<Item = &'a [DataType]> + 'a>>> {
+    ) -> Option<Option<Box<Iterator<Item = Cow<'a, [DataType]>> + 'a>>> {
         impl_ingredient_fn_ref!(self, lookup, parent, columns, key, domain, states)
     }
     fn parent_columns(&self, column: usize) -> Vec<(NodeIndex, Option<usize>)> {

--- a/dataflow/src/ops/topk.rs
+++ b/dataflow/src/ops/topk.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::mem;
 use std::collections::HashMap;
 use std::cmp::Ordering;
@@ -9,7 +10,7 @@ use nom_sql::OrderType;
 #[derive(Clone, Serialize, Deserialize)]
 struct Order(Vec<(usize, OrderType)>);
 impl Order {
-    fn cmp(&self, a: &&Vec<DataType>, b: &&Vec<DataType>) -> Ordering {
+    fn cmp(&self, a: &Vec<DataType>, b: &Vec<DataType>) -> Ordering {
         for &(c, ref order_type) in &self.0 {
             let result = match *order_type {
                 OrderType::OrderAscending => a[c].cmp(&b[c]),
@@ -96,7 +97,7 @@ impl TopK {
     ) -> Records {
         let mut delta: Vec<Record> = Vec::new();
         let mut current: Vec<&Row> = current_topk.iter().collect();
-        current.sort_by(|a, b| self.order.cmp(&&***a, &&***b));
+        current.sort_by(|a, b| self.order.cmp(&***a, &&***b));
         for r in new.iter() {
             if let &Record::Negative(ref a) = r {
                 let idx = current.binary_search_by(|row| self.order.cmp(&&***row, &&a));
@@ -107,12 +108,12 @@ impl TopK {
             }
         }
 
-        let mut output_rows: Vec<(&Vec<DataType>, bool)> = new.iter()
+        let mut output_rows: Vec<(Vec<DataType>, bool)> = new.into_iter()
             .filter_map(|r| match r {
-                &Record::Positive(ref a) => Some((&*a, false)),
+                Record::Positive(a) => Some((a, false)),
                 _ => None,
             })
-            .chain(current.into_iter().map(|a| (&**a, true)))
+            .chain(current.into_iter().map(|a| ((**a).clone(), true)))
             .collect();
         output_rows.sort_by(|a, b| self.order.cmp(&a.0, &b.0));
 
@@ -127,38 +128,68 @@ impl TopK {
 
             // Get the minimum element of output_rows.
             if let Some((min, _)) = output_rows.iter().cloned().next() {
-                let is_min = |&&(ref r, _): &&(&Vec<DataType>, bool)| {
-                    self.order.cmp(&&r, &&min) == Ordering::Equal
+                let is_min = |&&(ref r, _): &&(Vec<DataType>, bool)| {
+                    self.order.cmp(&r, &min) == Ordering::Equal
                 };
 
                 let mut current_mins: Vec<_> = output_rows.iter().filter(is_min).cloned().collect();
 
-                output_rows = rs.iter()
-                    .filter_map(|r| {
-                        // Make sure that no duplicates are added to output_rows. This is simplified
-                        // by the fact that it currently contains all rows greater than `min`, and
-                        // none less than it. The only complication are rows which compare equal to
-                        // `min`: they get added except if there is already an identical row.
-                        match self.order.cmp(&&**r, &&min) {
-                            Ordering::Less => Some((r, false)),
-                            Ordering::Equal => {
-                                let e = current_mins.iter().position(|&(ref s, _)| **s == **r);
-                                match e {
-                                    Some(i) => {
-                                        current_mins.swap_remove(i);
-                                        None
+                output_rows = match rs {
+                    // TODO(ekmartin): try to refactor these (almost) duplicate branches:
+                    Cow::Borrowed(rs) => rs.iter()
+                        .filter_map(|r| {
+                            // Make sure that no duplicates are added to output_rows. This is simplified
+                            // by the fact that it currently contains all rows greater than `min`, and
+                            // none less than it. The only complication are rows which compare equal to
+                            // `min`: they get added except if there is already an identical row.
+                            match self.order.cmp(&&**r, &&min) {
+                                Ordering::Less => Some((r, false)),
+                                Ordering::Equal => {
+                                    let e = current_mins.iter().position(|&(ref s, _)| *s == **r);
+                                    match e {
+                                        Some(i) => {
+                                            current_mins.swap_remove(i);
+                                            None
+                                        }
+                                        None => Some((r, false)),
                                     }
-                                    None => Some((r, false)),
                                 }
+                                Ordering::Greater => None,
                             }
-                            Ordering::Greater => None,
-                        }
-                    })
-                    .map(|(r, p)| (&**r, p))
-                    .chain(output_rows.into_iter())
-                    .collect();
+                        })
+                        .map(|(r, p)| ((**r).clone(), p))
+                        .chain(output_rows.into_iter())
+                        .collect(),
+                    Cow::Owned(rs) => rs.into_iter()
+                        .filter_map(|r| {
+                            // Make sure that no duplicates are added to output_rows. This is simplified
+                            // by the fact that it currently contains all rows greater than `min`, and
+                            // none less than it. The only complication are rows which compare equal to
+                            // `min`: they get added except if there is already an identical row.
+                            match self.order.cmp(&&*r, &&min) {
+                                Ordering::Less => Some((r, false)),
+                                Ordering::Equal => {
+                                    let e = current_mins.iter().position(|&(ref s, _)| *s == *r);
+                                    match e {
+                                        Some(i) => {
+                                            current_mins.swap_remove(i);
+                                            None
+                                        }
+                                        None => Some((r, false)),
+                                    }
+                                }
+                                Ordering::Greater => None,
+                            }
+                        })
+                        .map(|(r, p)| (r.unpack(), p))
+                        .chain(output_rows.into_iter())
+                        .collect(),
+                };
             } else {
-                output_rows = rs.iter().map(|rs| (&**rs, false)).collect();
+                output_rows = match rs {
+                    Cow::Borrowed(rs) => rs.iter().map(|r| ((**r).clone(), false)).collect(),
+                    Cow::Owned(rs) => rs.into_iter().map(|r| (r.unpack(), false)).collect(),
+                };
             }
             output_rows.sort_by(|a, b| self.order.cmp(&a.0, &b.0));
         }
@@ -178,7 +209,7 @@ impl TopK {
                 bottom_rows
                     .into_iter()
                     .filter(|p| p.1)
-                    .map(|p| Record::Negative(p.0.clone())),
+                    .map(|p| Record::Negative(p.0)),
             );
         }
 
@@ -187,7 +218,7 @@ impl TopK {
             output_rows
                 .into_iter()
                 .filter(|p| !p.1)
-                .map(|p| Record::Positive(p.0.clone())),
+                .map(|p| Record::Positive(p.0)),
         );
         delta.into()
     }

--- a/dataflow/src/ops/topk.rs
+++ b/dataflow/src/ops/topk.rs
@@ -315,7 +315,7 @@ impl Ingredient for TopK {
                 } else {
                     assert!(count as usize >= old_rs.len());
 
-                    out.append(&mut self.apply(old_rs, diffs.into(), state, &group[..]).into());
+                    out.append(&mut self.apply(&old_rs, diffs.into(), state, &group[..]).into());
                 }
                 self.counts.insert(group, (count + count_diff) as usize);
             }

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -25,6 +25,8 @@ pub struct Parameters {
     pub mode: DurabilityMode,
     /// Filename prefix for persistent log entries.
     pub log_prefix: String,
+    /// Whether PersistentState or MemoryState should be used for base nodes:
+    pub persist_base_nodes: bool,
 }
 
 impl Default for Parameters {
@@ -34,6 +36,7 @@ impl Default for Parameters {
             flush_timeout: time::Duration::new(0, 100_000),
             mode: DurabilityMode::MemoryOnly,
             log_prefix: String::from("soup"),
+            persist_base_nodes: true,
         }
     }
 }
@@ -57,6 +60,7 @@ impl Parameters {
         queue_capacity: usize,
         flush_timeout: time::Duration,
         log_prefix: Option<String>,
+        persist_base_nodes: bool,
     ) -> Self {
         let log_prefix = log_prefix.unwrap_or(String::from("soup"));
         assert!(!log_prefix.contains("-"));
@@ -66,6 +70,7 @@ impl Parameters {
             flush_timeout,
             mode,
             log_prefix,
+            persist_base_nodes,
         }
     }
 

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -183,33 +183,36 @@ impl GroupCommitQueueSet {
         nodes: &DomainNodes,
         ex: &Executor,
     ) -> Option<Box<Packet>> {
-        match self.params.mode {
-            DurabilityMode::DeleteOnExit | DurabilityMode::Permanent => {
-                if !self.files.contains_key(node) {
-                    let file = self.get_or_create_file(node, nodes);
-                    self.files.insert(node.clone(), file);
-                }
-
-                let mut file = &mut self.files[node].1;
-                {
-                    let data_to_flush: Vec<_> = self.pending_packets[&node]
-                        .iter()
-                        .map(|p| match **p {
-                            Packet::Transaction { ref data, .. }
-                            | Packet::Message { ref data, .. } => data,
-                            _ => unreachable!(),
-                        })
-                        .collect();
-                    serde_json::to_writer(&mut file, &data_to_flush).unwrap();
-                    // Separate log flushes with a newline so that the
-                    // file can be easily parsed later on:
-                    writeln!(&mut file, "").unwrap();
-                }
-
-                file.flush().unwrap();
-                file.get_mut().sync_data().unwrap();
+        // With persistent bases we're already maintaining a write-ahead log,
+        // so no need to log twice.
+        if !self.params.persist_base_nodes
+            && (self.params.mode == DurabilityMode::DeleteOnExit
+                || self.params.mode == DurabilityMode::Permanent)
+        {
+            if !self.files.contains_key(node) {
+                let file = self.get_or_create_file(node, nodes);
+                self.files.insert(node.clone(), file);
             }
-            DurabilityMode::MemoryOnly => {}
+
+            let mut file = &mut self.files[node].1;
+            {
+                let data_to_flush: Vec<_> = self.pending_packets[&node]
+                    .iter()
+                    .map(|p| match **p {
+                        Packet::Transaction { ref data, .. } | Packet::Message { ref data, .. } => {
+                            data
+                        }
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                serde_json::to_writer(&mut file, &data_to_flush).unwrap();
+                // Separate log flushes with a newline so that the
+                // file can be easily parsed later on:
+                writeln!(&mut file, "").unwrap();
+            }
+
+            file.flush().unwrap();
+            file.get_mut().sync_data().unwrap();
         }
 
         self.wait_start.remove(node);

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -14,17 +14,6 @@ use domain;
 use prelude::*;
 use checktable;
 
-/// Indicates to what degree updates should be persisted.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub enum DurabilityMode {
-    /// Don't do any durability
-    MemoryOnly,
-    /// Delete any log files on exit. Useful mainly for tests.
-    DeleteOnExit,
-    /// Persist updates to disk, and don't delete them later.
-    Permanent,
-}
-
 /// Parameters to control the operation of GroupCommitQueue.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Parameters {

--- a/dataflow/src/persistence/mod.rs
+++ b/dataflow/src/persistence/mod.rs
@@ -183,37 +183,30 @@ impl GroupCommitQueueSet {
         nodes: &DomainNodes,
         ex: &Executor,
     ) -> Option<Box<Packet>> {
-        // With persistent bases we're already maintaining a write-ahead log,
-        // so no need to log twice.
-        if !self.params.persist_base_nodes
-            && (self.params.mode == DurabilityMode::DeleteOnExit
-                || self.params.mode == DurabilityMode::Permanent)
-        {
-            if !self.files.contains_key(node) {
-                let file = self.get_or_create_file(node, nodes);
-                self.files.insert(node.clone(), file);
-            }
-
-            let mut file = &mut self.files[node].1;
-            {
-                let data_to_flush: Vec<_> = self.pending_packets[&node]
-                    .iter()
-                    .map(|p| match **p {
-                        Packet::Transaction { ref data, .. } | Packet::Message { ref data, .. } => {
-                            data
-                        }
-                        _ => unreachable!(),
-                    })
-                    .collect();
-                serde_json::to_writer(&mut file, &data_to_flush).unwrap();
-                // Separate log flushes with a newline so that the
-                // file can be easily parsed later on:
-                writeln!(&mut file, "").unwrap();
-            }
-
-            file.flush().unwrap();
-            file.get_mut().sync_data().unwrap();
+        if !self.files.contains_key(node) {
+            let file = self.get_or_create_file(node, nodes);
+            self.files.insert(node.clone(), file);
         }
+
+        let mut file = &mut self.files[node].1;
+        {
+            let data_to_flush: Vec<_> = self.pending_packets[&node]
+                .iter()
+                .map(|p| match **p {
+                    Packet::Transaction { ref data, .. } | Packet::Message { ref data, .. } => {
+                        data
+                    }
+                    _ => unreachable!(),
+                })
+                .collect();
+            serde_json::to_writer(&mut file, &data_to_flush).unwrap();
+            // Separate log flushes with a newline so that the
+            // file can be easily parsed later on:
+            writeln!(&mut file, "").unwrap();
+        }
+
+        file.flush().unwrap();
+        file.get_mut().sync_data().unwrap();
 
         self.wait_start.remove(node);
         Self::merge_packets(&mut self.pending_packets[node], nodes, ex)

--- a/dataflow/src/processing.rs
+++ b/dataflow/src/processing.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use ops::base::Base;
@@ -166,7 +167,7 @@ where
         _columns: &[usize],
         _key: &prelude::KeyType,
         _states: &'a prelude::StateMap,
-    ) -> Option<Option<Box<Iterator<Item = &'a [prelude::DataType]> + 'a>>> {
+    ) -> Option<Option<Box<Iterator<Item = Cow<'a, [prelude::DataType]>> + 'a>>> {
         None
     }
 
@@ -183,12 +184,15 @@ where
         key: &prelude::KeyType,
         domain: &prelude::DomainNodes,
         states: &'a prelude::StateMap,
-    ) -> Option<Option<Box<Iterator<Item = &'a [prelude::DataType]> + 'a>>> {
+    ) -> Option<Option<Box<Iterator<Item = Cow<'a, [prelude::DataType]>> + 'a>>> {
         states
             .get(&parent)
             .and_then(move |state| match state.lookup(columns, key) {
-                prelude::LookupResult::Some(rs) => {
-                    Some(Some(Box::new(rs.iter().map(|r| &r[..])) as Box<_>))
+                prelude::LookupResult::Some(Cow::Owned(rs)) => {
+                    Some(Some(Box::new(rs.into_iter().map(|r| Cow::Owned(r.unpack()))) as Box<_>))
+                }
+                prelude::LookupResult::Some(Cow::Borrowed(rs)) => {
+                    Some(Some(Box::new(rs.iter().map(|r| Cow::Borrowed(&r[..]))) as Box<_>))
                 }
                 prelude::LookupResult::Missing => Some(None),
             })

--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -25,6 +25,7 @@ fn main() {
         512,
         Duration::from_millis(1),
         Some(String::from("example")),
+        true,
     );
 
     // set up Soup via recipe

--- a/src/bin/souplet.rs
+++ b/src/bin/souplet.rs
@@ -130,6 +130,7 @@ fn main() {
         512,
         Duration::new(0, 100_000),
         Some(deployment_name.to_string()),
+        true,
     );
     builder.set_persistence(persistence_params);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,12 +354,12 @@ mod tests;
 
 pub use consensus::{LocalAuthority, ZookeeperAuthority};
 
-pub use core::{DataType, Datas, NodeIndex};
+pub use core::{DataType, Datas, DurabilityMode, NodeIndex};
 
 pub use dataflow::checktable::{Token, TransactionResult};
 pub use dataflow::debug::{DebugEvent, DebugEventType};
 pub use dataflow::prelude::DomainIndex;
-pub use dataflow::{DurabilityMode, PersistenceParameters};
+pub use dataflow::PersistenceParameters;
 
 pub use controller::sql::reuse::ReuseConfigType;
 pub use controller::{Controller, ControllerBuilder, ControllerHandle, Mutator, MutatorBuilder,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 extern crate glob;
 
-use core::DataType;
+use core::{DataType, DurabilityMode};
 use dataflow::checktable::Token;
 use dataflow::ops::base::Base;
 use dataflow::ops::grouped::aggregate::Aggregation;
@@ -9,8 +9,8 @@ use dataflow::ops::join::{Join, JoinSource, JoinType};
 use dataflow::ops::join::JoinSource::*;
 use dataflow::ops::project::Project;
 use dataflow::ops::union::Union;
-use dataflow::{DurabilityMode, PersistenceParameters};
 use consensus::LocalAuthority;
+use dataflow::PersistenceParameters;
 use controller::ControllerBuilder;
 use controller::recipe::Recipe;
 use controller::sql::SqlIncorporator;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -560,7 +560,7 @@ fn it_recovers_persisted_logs() {
         128,
         Duration::from_millis(1),
         Some(log_name.name.clone()),
-        true,
+        false,
     );
 
     {
@@ -657,7 +657,7 @@ fn it_recovers_persisted_logs_w_multiple_nodes() {
         128,
         Duration::from_millis(1),
         Some(log_name.name.clone()),
-        true,
+        false,
     );
 
     {
@@ -705,7 +705,7 @@ fn it_recovers_persisted_logs_w_transactions() {
         128,
         Duration::from_millis(1),
         Some(log_name.name.clone()),
-        true,
+        false,
     );
 
     {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -80,6 +80,7 @@ fn it_works_basic() {
         128,
         Duration::from_millis(1),
         Some(get_log_name("it_works_basic")),
+        true,
     ));
     let mut g = b.build_local();
     let _ = g.migrate(|mig| {
@@ -559,6 +560,7 @@ fn it_recovers_persisted_logs() {
         128,
         Duration::from_millis(1),
         Some(log_name.name.clone()),
+        true,
     );
 
     {
@@ -655,6 +657,7 @@ fn it_recovers_persisted_logs_w_multiple_nodes() {
         128,
         Duration::from_millis(1),
         Some(log_name.name.clone()),
+        true,
     );
 
     {
@@ -702,6 +705,7 @@ fn it_recovers_persisted_logs_w_transactions() {
         128,
         Duration::from_millis(1),
         Some(log_name.name.clone()),
+        true,
     );
 
     {


### PR DESCRIPTION
This implements persistent indices for Soup base nodes using SQlite, as a baseline for future experiments.

### Overview
At an API level it converts `State` into an enum that can be either `MemoryState` or `PersistentState` - with the latter now being used for base nodes. 

### Storage
Each instance of `PersistentState` corresponds to one table in SQlite. The table contains one column for each index and a single `row` column that stores a serialized representation of the `Vec<DataType>`. This might not be the right approach, so let me know if you have any better ideas!

#### Adding indices
`add_key` makes sure that there's a separate `index_#` column for all the parts of the given `columns` and finally adds a combined index using `CREATE INDEX`. This means that any rows that were inserted prior to `add_key` being called won't contain the new index columns though, so might be worth going through and backfilling those.

#### Look-ups
`lookup` builds up a `SELECT` query using the indices available in `columns`, on the form of `SELECT row FROM table_name WHERE index_0 = x AND index_1 = x AND ....`.

#### Removals
`remove` plucks out all the index values from the given row and performs a `DELETE FROM` with those.

#### Inserts
`insert` finds all the index values from the given row (from `self.indices`) and inserts them into separate `index_#` columns. The whole row gets put into a `row` column, after being serialized to JSON. This could probably be a `BLOB` column and use `bincode` instead as well.

### Future work
This mostly just implements the API - haven't run any benchmarks yet. This also performs an `INSERT` on every batch update, which with autocommit probably causes a disk write. @jonhoo suggested earlier that a possible solution might write on every update, but only flush to disk before the batch packet is inserted into the graph. Maybe this could be implemented by creating a transaction, and only committing it prior to insertion into the graph - not sure yet.