### PR TITLE
Add failing test for empty read before writes

### DIFF
--- a/examples/basic-recipe.rs
+++ b/examples/basic-recipe.rs
@@ -33,6 +33,10 @@ fn main() {
     builder.set_worker_threads(2);
     builder.set_persistence(persistence_params);
 
+    // TODO: This should be removed when the `it_works_with_reads_before_writes`
+    // test passes again.
+    builder.disable_partial();
+
     let mut blender = builder.build_local();
     blender.install_recipe(sql.to_owned()).unwrap();
     println!("{}", blender.graphviz());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -424,6 +424,7 @@ fn it_works_with_sql_recipe() {
 }
 
 #[test]
+#[allow_fail]
 fn it_works_with_reads_before_writes() {
     let mut g = ControllerBuilder::default().build_local();
     let sql = "
@@ -442,8 +443,8 @@ fn it_works_with_reads_before_writes() {
     let aid = 1;
     let uid = 10;
 
-    // TODO: For some reason it seems like performing a read here makes the read later on return
-    // empty results as well.
+    // TODO: This lookup results in the partial key being populated
+    // with an empty result, which leads to the second read not replaying correctly.
     assert!(awvc.lookup(&aid.into(), true).unwrap().is_empty());
 
     article.put(vec![aid.into()]).unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -424,6 +424,40 @@ fn it_works_with_sql_recipe() {
 }
 
 #[test]
+fn it_works_with_reads_before_writes() {
+    let mut g = ControllerBuilder::default().build_local();
+    let sql = "
+        CREATE TABLE Article (aid int, PRIMARY KEY(aid));
+        CREATE TABLE Vote (aid int, uid int);
+        QUERY ArticleVote: SELECT Article.aid, Vote.uid \
+            FROM Article, Vote \
+            WHERE Article.aid = Vote.aid AND Article.aid = ?;
+    ";
+
+    g.install_recipe(sql.to_owned()).unwrap();
+    let mut article = g.get_mutator("Article").unwrap();
+    let mut vote = g.get_mutator("Vote").unwrap();
+    let mut awvc = g.get_getter("ArticleVote").unwrap();
+
+    let aid = 1;
+    let uid = 10;
+
+    // TODO: For some reason it seems like performing a read here makes the read later on return
+    // empty results as well.
+    assert!(awvc.lookup(&aid.into(), true).unwrap().is_empty());
+
+    article.put(vec![aid.into()]).unwrap();
+    sleep();
+
+    vote.put(vec![aid.into(), uid.into()]).unwrap();
+    sleep();
+
+    let result = awvc.lookup(&aid.into(), true).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], vec![aid.into(), uid.into()]);
+}
+
+#[test]
 fn forced_shuffle_despite_same_shard() {
     // XXX: this test doesn't currently *fail* despite
     // multiple trailing replay responses that are simply ignored...


### PR DESCRIPTION
Also disables partial materialization in the `basic-recipe` example, so it works until the issue has been fixed.