### PR TITLE
Send write-ACKs only after process(..) is done

### DIFF
--- a/dataflow/src/lib.rs
+++ b/dataflow/src/lib.rs
@@ -56,7 +56,7 @@ pub type PersistenceParameters = persistence::Parameters;
 pub type DomainConfig = domain::Config;
 
 pub use persistence::DurabilityMode;
-pub use domain::{Domain, DomainBuilder, Executor, Index};
+pub use domain::{Domain, DomainBuilder, Index};
 pub use payload::{LocalBypass, Packet};
 pub use checktable::connect_thread_checktable;
 

--- a/dataflow/src/payload.rs
+++ b/dataflow/src/payload.rs
@@ -127,6 +127,7 @@ pub enum Packet {
         src: Option<SourceChannelIdentifier>,
         data: Records,
         tracer: Tracer,
+        senders: Vec<SourceChannelIdentifier>,
     },
 
     /// Transactional data-flow update.
@@ -136,6 +137,7 @@ pub enum Packet {
         data: Records,
         state: TransactionState,
         tracer: Tracer,
+        senders: Vec<SourceChannelIdentifier>,
     },
 
     /// Update that is part of a tagged data-flow replay path.
@@ -390,11 +392,13 @@ impl Packet {
                 src: _,
                 ref data,
                 ref tracer,
+                ref senders,
             } => Packet::Message {
                 link: link.clone(),
                 src: None,
                 data: data.clone(),
                 tracer: tracer.clone(),
+                senders: senders.clone(),
             },
             Packet::Transaction {
                 ref link,
@@ -402,12 +406,14 @@ impl Packet {
                 ref data,
                 ref state,
                 ref tracer,
+                ref senders,
             } => Packet::Transaction {
                 link: link.clone(),
                 src: None,
                 data: data.clone(),
                 state: state.clone(),
                 tracer: tracer.clone(),
+                senders: senders.clone(),
             },
             Packet::ReplayPiece {
                 ref link,

--- a/dataflow/src/prelude.rs
+++ b/dataflow/src/prelude.rs
@@ -12,7 +12,8 @@ pub type Edge = ();
 pub type Graph = petgraph::Graph<Node, Edge>;
 
 // dataflow types
-pub use payload::{Link, Packet, PacketEvent, ReplayPathSegment, Tracer, TransactionState};
+pub use payload::{Link, Packet, PacketEvent, ReplayPathSegment, SourceChannelIdentifier, Tracer,
+                  TransactionState};
 pub use Sharding;
 
 // domain local state
@@ -25,6 +26,9 @@ use channel;
 use domain;
 /// Channel coordinator type specialized for domains
 pub type ChannelCoordinator = channel::ChannelCoordinator<(DomainIndex, usize)>;
+pub trait Executor {
+    fn send_back(&self, SourceChannelIdentifier, Result<i64, ()>);
+}
 
 // debug types
 pub use debug::DebugEvent;

--- a/src/controller/mutator.rs
+++ b/src/controller/mutator.rs
@@ -147,6 +147,7 @@ impl Mutator {
                 data: rs,
                 state: TransactionState::WillCommit,
                 tracer: self.tracer.clone(),
+                senders: vec![],
             }
         } else {
             box Packet::Message {
@@ -154,6 +155,7 @@ impl Mutator {
                 src: None,
                 data: rs,
                 tracer: self.tracer.clone(),
+                senders: vec![],
             }
         }
     }
@@ -176,6 +178,7 @@ impl Mutator {
             data: rs,
             state: TransactionState::Pending(t),
             tracer: self.tracer.clone(),
+            senders: vec![],
         };
 
         self.domain_input_handle

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -818,7 +818,7 @@ impl Worker {
     }
 }
 
-impl dataflow::Executor for ReplicaReceivers {
+impl dataflow::prelude::Executor for ReplicaReceivers {
     fn send_back(&self, channel: SourceChannelIdentifier, reply: Result<i64, ()>) {
         if let Some(ch) = self.get(channel.token) {
             use bincode;


### PR DESCRIPTION
This makes it possible to send back more information with the ACKs than what's currently being done. An `AUTO_INCREMENT` implementation could e.g. be handled in each base operator, by returning the newly selected ID from `on_input`.

This also helps with stuff like the persistent bases implementation, where writes are persisted in `materialize` (meaning that ACKs sent from `persistence` would be premature).

Unfortunately this seems to increase write latencies with about ~10% at the 95th and 99th percentiles, which is probably just a result of the domain having to do more work (such as materializing updates) before returning an ACK. Happy to hear other suggestions for how this could be implemented too.