### PR TITLE
Fix column order for vote writes

### DIFF
--- a/benchmarks/vote/clients/localsoup/graph.rs
+++ b/benchmarks/vote/clients/localsoup/graph.rs
@@ -3,14 +3,14 @@ use distributary::{self, ControllerBuilder, ControllerHandle, LocalAuthority, No
 
 pub(crate) const RECIPE: &str = "# base tables
 CREATE TABLE Article (id int, title varchar(255), PRIMARY KEY(id));
-CREATE TABLE Vote (id int, user int, PRIMARY KEY(id));
+CREATE TABLE Vote (article_id int, user int);
 
 # read queries
 QUERY ArticleWithVoteCount: SELECT Article.id, title, VoteCount.votes AS votes \
             FROM Article \
-            LEFT JOIN (SELECT Vote.id, COUNT(user) AS votes \
-                       FROM Vote GROUP BY Vote.id) AS VoteCount \
-            ON (Article.id = VoteCount.id) WHERE Article.id = ?;";
+            LEFT JOIN (SELECT Vote.article_id, COUNT(user) AS votes \
+                       FROM Vote GROUP BY Vote.article_id) AS VoteCount \
+            ON (Article.id = VoteCount.article_id) WHERE Article.id = ?;";
 
 pub struct Graph {
     setup: Setup,

--- a/benchmarks/vote/clients/localsoup/mod.rs
+++ b/benchmarks/vote/clients/localsoup/mod.rs
@@ -77,7 +77,7 @@ impl VoteClient for Client {
 
     fn handle_writes(&mut self, ids: &[i32]) {
         let data: Vec<Vec<DataType>> = ids.into_iter()
-            .map(|&article_id| vec![0.into(), (article_id as usize).into()])
+            .map(|&article_id| vec![(article_id as usize).into(), 0.into()])
             .collect();
 
         self.w.multi_put(data).unwrap();

--- a/benchmarks/vote/clients/netsoup.rs
+++ b/benchmarks/vote/clients/netsoup.rs
@@ -55,7 +55,7 @@ impl VoteClient for Client {
 
     fn handle_writes(&mut self, ids: &[i32]) {
         let data: Vec<Vec<DataType>> = ids.into_iter()
-            .map(|&article_id| vec![0.into(), (article_id as usize).into()])
+            .map(|&article_id| vec![(article_id as usize).into(), 0.into()])
             .collect();
 
         self.w.multi_put(data).unwrap();


### PR DESCRIPTION
Also renamed `Vote.id` to `Vote.article_id` to make things clearer. Preferably `Vote` should have `PRIMARY KEY (article_id, user)` but at the moment that crashes with a `got backfill for unnecessary key` error.