### PR TITLE
Fix core tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: rust
 rust:
-  - nightly-2018-02-14
+  - nightly-2018-03-17
 cache: cargo
 env:
   - SETTLE_TIME=2000

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,6 @@ dependencies = [
  "rahashmap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["The Distributary Developers"]
 arccstr = "1.0.4"
 fnv = "1.0.5"
 serde_derive = "1.0.8"
-serde_json = "1.0.2"
 rahashmap = "0.2.0"
 
 # need features

--- a/core/src/data.rs
+++ b/core/src/data.rs
@@ -989,12 +989,12 @@ mod tests {
         // DataType should always use 16 bytes itself
         assert_eq!(size_of::<DataType>(), 16);
         assert_eq!(size_of_val(&txt), 16);
-        assert_eq!(size_of_val(&txt), txt.size_of());
+        assert_eq!(size_of_val(&txt) as u64, txt.size_of());
         assert_eq!(txt.deep_size_of(), txt.size_of() + 8 + 2); // DataType + ArcCStr's ptr + 2 chars
         assert_eq!(size_of_val(&shrt), 16);
         assert_eq!(size_of_val(&long), 16);
         assert_eq!(size_of_val(&time), 16);
-        assert_eq!(size_of_val(&time), time.size_of());
+        assert_eq!(size_of_val(&time) as u64, time.size_of());
         assert_eq!(time.deep_size_of(), 16); // DataType + inline NaiveDateTime
 
         assert_eq!(size_of_val(&rec), 24);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,10 +15,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
-#[cfg(any(feature = "web", test))]
-#[macro_use]
-extern crate serde_json;
-
 pub mod addressing;
 pub mod data;
 pub mod local;


### PR DESCRIPTION
Just two tiny `as u64` casts that were missing for the `core` tests to pass.