### PR TITLE
Refactor LookupResult

### DIFF
--- a/basics/src/lib.rs
+++ b/basics/src/lib.rs
@@ -29,7 +29,7 @@ use std::time;
 
 pub use addressing::{IndexPair, LocalNodeIndex};
 pub use data::{BaseOperation, DataType, Datas, Modification, Operation, Record, Records};
-pub use local::{KeyType, LookupResult, MemoryState, PersistentState, Row, State, Tag};
+pub use local::{KeyType, LookupResult, MemoryState, PersistentState, RecordResult, Row, State, Tag};
 pub use map::Map;
 pub use petgraph::graph::NodeIndex;
 

--- a/basics/src/local/memory_state.rs
+++ b/basics/src/local/memory_state.rs
@@ -241,7 +241,7 @@ mod tests {
 
         // Make sure the first record has been deleted:
         match state.lookup(&[0], &KeyType::Single(&records[0][0])) {
-            LookupResult::Some(rows) => assert_eq!(rows.len(), 0),
+            LookupResult::Some(RecordResult::Borrowed(rows)) => assert_eq!(rows.len(), 0),
             _ => unreachable!(),
         };
 
@@ -249,7 +249,9 @@ mod tests {
         for i in 1..3 {
             let record = &records[i];
             match state.lookup(&[0], &KeyType::Single(&record[0])) {
-                LookupResult::Some(rows) => assert_eq!(&*rows[0], &**record),
+                LookupResult::Some(RecordResult::Borrowed(rows)) => {
+                    assert_eq!(&*rows[0], &**record)
+                }
                 _ => unreachable!(),
             };
         }
@@ -264,7 +266,7 @@ mod tests {
         state.add_key(&[1], None);
 
         match state.lookup(&[1], &KeyType::Single(&row[1])) {
-            LookupResult::Some(rows) => assert_eq!(&*rows[0], &row),
+            LookupResult::Some(RecordResult::Borrowed(rows)) => assert_eq!(&*rows[0], &row),
             _ => unreachable!(),
         };
     }

--- a/basics/src/local/mod.rs
+++ b/basics/src/local/mod.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -55,18 +54,10 @@ impl Tag {
     }
 }
 
-// TODO: Wrapping this in a Rc is unnecessary when rows are returned through a Cow::Owned from
-// PersistentState. This could be solved by having something similar to a Cow here.
 #[derive(Clone, Debug)]
 pub struct Row(pub(crate) Rc<Vec<DataType>>);
 
 unsafe impl Send for Row {}
-
-impl Row {
-    pub fn unpack(self) -> Vec<DataType> {
-        Rc::try_unwrap(self.0).unwrap()
-    }
-}
 
 impl Deref for Row {
     type Target = Vec<DataType>;
@@ -84,8 +75,23 @@ impl SizeOf for Row {
     }
 }
 
+/// An std::borrow::Cow-like wrapper around a collection of rows.
+pub enum RecordResult<'a> {
+    Borrowed(&'a [Row]),
+    Owned(Vec<Vec<DataType>>),
+}
+
+impl<'a> RecordResult<'a> {
+    pub fn len(&self) -> usize {
+        match *self {
+            RecordResult::Borrowed(rs) => rs.len(),
+            RecordResult::Owned(ref rs) => rs.len(),
+        }
+    }
+}
+
 pub enum LookupResult<'a> {
-    Some(Cow<'a, [Row]>),
+    Some(RecordResult<'a>),
     Missing,
 }
 

--- a/basics/src/local/single_state.rs
+++ b/basics/src/local/single_state.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use ::*;
 use rand::{Rng, ThreadRng};
 use local::keyed_state::KeyedState;
@@ -322,13 +320,13 @@ impl SingleState {
     }
     pub fn lookup<'a>(&'a self, key: &KeyType) -> LookupResult<'a> {
         if let Some(rs) = self.state.lookup(key) {
-            LookupResult::Some(Cow::Borrowed(&rs[..]))
+            LookupResult::Some(RecordResult::Borrowed(&rs[..]))
         } else {
             if self.partial() {
                 // partially materialized, so this is a hole (empty results would be vec![])
                 LookupResult::Missing
             } else {
-                LookupResult::Some(Cow::Owned(vec![]))
+                LookupResult::Some(RecordResult::Owned(vec![]))
             }
         }
     }

--- a/benchmarks/vote/main.rs
+++ b/benchmarks/vote/main.rs
@@ -1,4 +1,5 @@
 #![deny(unused_extern_crates)]
+#![feature(duration_from_micros)]
 
 #[macro_use]
 extern crate clap;

--- a/dataflow/src/ops/base.rs
+++ b/dataflow/src/ops/base.rs
@@ -179,9 +179,10 @@ impl Ingredient for Base {
 
         let get_current = |current_key: &'_ _| {
             match db.lookup(key_cols, &KeyType::from(current_key)) {
-                LookupResult::Some(ref rows) if rows.len() != 1 => {
+                LookupResult::Some(rows) => {
                     match rows.len() {
                         0 => None,
+                        1 => rows.into_iter().next(),
                         n => {
                             // primary key, so better be unique!
                             assert_eq!(n, 1, "key {:?} not unique (n = {})!", current_key, n);
@@ -189,10 +190,6 @@ impl Ingredient for Base {
                         }
                     }
                 }
-                LookupResult::Some(RecordResult::Owned(mut rows)) => {
-                    Some(Cow::from(rows.pop().unwrap()))
-                }
-                LookupResult::Some(RecordResult::Borrowed(rows)) => Some(Cow::from(&rows[0][..])),
                 LookupResult::Missing => unreachable!(),
             }
         };

--- a/dataflow/src/ops/base.rs
+++ b/dataflow/src/ops/base.rs
@@ -189,10 +189,10 @@ impl Ingredient for Base {
                         }
                     }
                 }
-                LookupResult::Some(Cow::Owned(mut rows)) => {
-                    Some(Cow::from(rows.pop().unwrap().unpack()))
+                LookupResult::Some(RecordResult::Owned(mut rows)) => {
+                    Some(Cow::from(rows.pop().unwrap()))
                 }
-                LookupResult::Some(Cow::Borrowed(rows)) => Some(Cow::from(&rows[0][..])),
+                LookupResult::Some(RecordResult::Borrowed(rows)) => Some(Cow::from(&rows[0][..])),
                 LookupResult::Missing => unreachable!(),
             }
         };

--- a/dataflow/src/ops/filter.rs
+++ b/dataflow/src/ops/filter.rs
@@ -204,16 +204,8 @@ impl Ingredient for Filter {
             };
 
             match state.lookup(columns, key) {
-                LookupResult::Some(RecordResult::Borrowed(rs)) => {
-                    let r = Box::new(rs.iter().filter(move |r| filter(&r[..])).map(|r| Cow::from(&r[..]))) as Box<_>;
-                    Some(Some(r))
-                }
-                LookupResult::Some(RecordResult::Owned(rs)) => {
-                    let r = Box::new(
-                        rs.into_iter()
-                            .filter(move |ref r| filter(r))
-                            .map(|r| Cow::from(r)),
-                    ) as Box<_>;
+                LookupResult::Some(rs) => {
+                    let r = Box::new(rs.into_iter().filter(move |r| filter(r))) as Box<_>;
                     Some(Some(r))
                 }
                 LookupResult::Missing => Some(None),

--- a/dataflow/src/ops/grouped/mod.rs
+++ b/dataflow/src/ops/grouped/mod.rs
@@ -223,15 +223,7 @@ where
                         }
                     };
 
-                    let old = match rs {
-                        RecordResult::Owned(rows) => {
-                            rows.into_iter().next().map(|rs| Cow::from(rs))
-                        }
-                        RecordResult::Borrowed(ref rows) => {
-                            rows.get(0).as_ref().map(|rs| Cow::from(&rs[..]))
-                        }
-                    };
-
+                    let old = rs.into_iter().next();
                     // current value is in the last output column
                     // or "" if there is no current group
                     let current = old.as_ref().map(|rows| match rows {

--- a/dataflow/src/ops/grouped/mod.rs
+++ b/dataflow/src/ops/grouped/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
@@ -222,15 +223,23 @@ where
                         }
                     };
 
-                    // TODO: take advantage of rs possibly being a Cow::Owned to avoid cloning
-                    // further down.
-                    let old = rs.get(0);
+                    let old = match rs {
+                        RecordResult::Owned(rows) => {
+                            rows.into_iter().next().map(|rs| Cow::from(rs))
+                        }
+                        RecordResult::Borrowed(ref rows) => {
+                            rows.get(0).as_ref().map(|rs| Cow::from(&rs[..]))
+                        }
+                    };
+
                     // current value is in the last output column
                     // or "" if there is no current group
-                    let current = old.map(|r| &r[r.len() - 1]);
+                    let current = old.as_ref().map(|rows| match rows {
+                        Cow::Borrowed(rs) => Cow::Borrowed(&rs[rs.len() - 1]),
+                        Cow::Owned(rs) => Cow::Owned(rs[rs.len() - 1].clone()),
+                    });
 
-                    // new is the result of applying all diffs for the group to the current
-                    // value
+                    // new is the result of applying all diffs for the group to the current value
                     let new = inner.apply(current.as_ref().map(|v| &**v), &mut diffs as &mut _);
                     match current {
                         Some(ref current) if new == **current => {
@@ -240,7 +249,7 @@ where
                             if let Some(old) = old {
                                 // revoke old value
                                 debug_assert!(current.is_some());
-                                out.push(Record::Negative((**old).clone()));
+                                out.push(Record::Negative(old.into_owned()));
                             }
 
                             // emit positive, which is group + new.

--- a/dataflow/src/ops/latest.rs
+++ b/dataflow/src/ops/latest.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 use prelude::*;
@@ -96,16 +95,15 @@ impl Ingredient for Latest {
 
             // buffer emitted records
             for (r, current_row) in currents {
-                match current_row {
-                    Cow::Owned(mut rs) => {
-                        if rs.len() > 0 {
-                            out.push(Record::Negative(rs.swap_remove(0).unpack()));
+                if current_row.len() > 0 {
+                    match current_row {
+                        RecordResult::Owned(mut rs) => {
+                            out.push(Record::Negative(rs.swap_remove(0)));
+                        }
+                        RecordResult::Borrowed(rs) => {
+                            out.push(Record::Negative((*rs[0]).clone()));
                         }
                     }
-                    Cow::Borrowed(rs) if rs.len() > 0 => {
-                        out.push(Record::Negative((*rs[0]).clone()));
-                    }
-                    _ => {}
                 }
 
                 // if there was a previous latest for this key, revoke old record

--- a/dataflow/src/ops/topk.rs
+++ b/dataflow/src/ops/topk.rs
@@ -237,12 +237,12 @@ impl Ingredient for TopK {
                         missed = false;
                         grpk = rs.len();
                         match rs {
-                            Cow::Borrowed(rs) => {
+                            RecordResult::Borrowed(rs) => {
                                 current.extend(rs.iter().map(|r| (Cow::Borrowed(&r[..]), false)));
                             }
-                            Cow::Owned(rs) => {
+                            RecordResult::Owned(rs) => {
                                 current.extend(
-                                    rs.into_iter().map(|r| (Cow::Owned(r.unpack()), false)),
+                                    rs.into_iter().map(|r| (Cow::Owned(r), false)),
                                 );
                             }
                         }

--- a/dataflow/src/ops/topk.rs
+++ b/dataflow/src/ops/topk.rs
@@ -236,16 +236,7 @@ impl Ingredient for TopK {
                     LookupResult::Some(rs) => {
                         missed = false;
                         grpk = rs.len();
-                        match rs {
-                            RecordResult::Borrowed(rs) => {
-                                current.extend(rs.iter().map(|r| (Cow::Borrowed(&r[..]), false)));
-                            }
-                            RecordResult::Owned(rs) => {
-                                current.extend(
-                                    rs.into_iter().map(|r| (Cow::Owned(r), false)),
-                                );
-                            }
-                        }
+                        current.extend(rs.into_iter().map(|r| (r, false)))
                     }
                     LookupResult::Missing => {
                         missed = true;

--- a/dataflow/src/processing.rs
+++ b/dataflow/src/processing.rs
@@ -224,12 +224,7 @@ where
         states
             .get(&parent)
             .and_then(move |state| match state.lookup(columns, key) {
-                LookupResult::Some(RecordResult::Owned(rs)) => Some(Some(Box::new(
-                    rs.into_iter().map(|r| Cow::Owned(r)),
-                ) as Box<_>)),
-                LookupResult::Some(RecordResult::Borrowed(rs)) => {
-                    Some(Some(Box::new(rs.iter().map(|r| Cow::Borrowed(&r[..]))) as Box<_>))
-                }
+                LookupResult::Some(rs) => Some(Some(Box::new(rs.into_iter()) as Box<_>)),
                 LookupResult::Missing => Some(None),
             })
             .or_else(|| {

--- a/dataflow/src/processing.rs
+++ b/dataflow/src/processing.rs
@@ -224,10 +224,10 @@ where
         states
             .get(&parent)
             .and_then(move |state| match state.lookup(columns, key) {
-                LookupResult::Some(Cow::Owned(rs)) => Some(Some(Box::new(
-                    rs.into_iter().map(|r| Cow::Owned(r.unpack())),
+                LookupResult::Some(RecordResult::Owned(rs)) => Some(Some(Box::new(
+                    rs.into_iter().map(|r| Cow::Owned(r)),
                 ) as Box<_>)),
-                LookupResult::Some(Cow::Borrowed(rs)) => {
+                LookupResult::Some(RecordResult::Borrowed(rs)) => {
                     Some(Some(Box::new(rs.iter().map(|r| Cow::Borrowed(&r[..]))) as Box<_>))
                 }
                 LookupResult::Missing => Some(None),


### PR DESCRIPTION
Implements a `Cow`-like enum where the `Owned` branch is a `Vec<Vec<DataType>>` and `Borrowed` is a `[Row]` - this lets us avoid `Row`'s `Rc` wrapper in the `Owned` case.